### PR TITLE
Display speed

### DIFF
--- a/ks_includes/printer.py
+++ b/ks_includes/printer.py
@@ -76,6 +76,7 @@ class Printer:
     def process_update(self, data):
         keys = [
             'bed_mesh',
+            'display_status',
             'fan',
             'gcode_move',
             'idle_timeout',

--- a/panels/job_status.py
+++ b/panels/job_status.py
@@ -136,18 +136,17 @@ class JobStatusPanel(ScreenPanel):
         self.labels['it_box'] = it_box
 
         position = self._gtk.Image("move.svg", None, .6, .6)
-        self.labels['pos_x'] = Gtk.Label(label="X: 0")
-        self.labels['pos_x'].get_style_context().add_class("printing-info")
-        self.labels['pos_y'] = Gtk.Label(label="Y: 0")
-        self.labels['pos_y'].get_style_context().add_class("printing-info")
         self.labels['pos_z'] = Gtk.Label(label="Z: 0")
         self.labels['pos_z'].get_style_context().add_class("printing-info")
+	self.labels['pos_z'].set_halign(Gtk.Align.START)
+	self.labels['printspeed'] = Gtk.Label(label="Speed: 0 mm/s")
+	self.labels['printspeed'].get_style_context().add_class("printing-info")
+	self.labels['printspeed'].set_halign(Gtk.Align.START)
         pos_box = Gtk.Box(spacing=0)
         posgrid = self._gtk.HomogeneousGrid()
         posgrid.set_hexpand(True)
-        posgrid.attach(self.labels['pos_x'], 0, 0, 1, 1)
-        posgrid.attach(self.labels['pos_y'], 1, 0, 1, 1)
-        posgrid.attach(self.labels['pos_z'], 2, 0, 1, 1)
+        posgrid.attach(self.labels['pos_z'], 0, 0, 1, 1)
+        posgrid.attach(self.labels['printspeed'], 1, 0, 1, 1)
         pos_box.add(position)
         pos_box.add(posgrid)
         self.labels['pos_box'] = pos_box
@@ -399,11 +398,11 @@ class JobStatusPanel(ScreenPanel):
                     self.current_extruder = data["toolhead"]["extruder"]
                     self.labels['temp_grid'].attach(self.labels[self.current_extruder + '_box'], 0, 0, 1, 1)
                     self._screen.show_all()
-            if "position" in data["toolhead"]:
-                self.labels['pos_x'].set_text("X: %.2f" % (data["toolhead"]["position"][0]))
-                self.labels['pos_y'].set_text("Y: %.2f" % (data["toolhead"]["position"][1]))
         if "gcode_move" in data and "gcode_position" in data["gcode_move"]:
             self.labels['pos_z'].set_text("Z: %.2f" % (data["gcode_move"]["gcode_position"][2]))
+        if "gcode_move" in data and "speed" in data["gcode_move"]:
+            self.labels['printspeed'].set_text("S: %d mm/s" % (data["gcode_move"]["speed"]/60))
+ 
 
         if "gcode_move" in data:
             #if "homing_origin" in data["gcode_move"]:

--- a/panels/job_status.py
+++ b/panels/job_status.py
@@ -50,9 +50,14 @@ class JobStatusPanel(ScreenPanel):
         self.labels['status'].set_halign(Gtk.Align.START)
         self.labels['status'].set_vexpand(False)
         self.labels['status'].get_style_context().add_class("printing-status")
+        self.labels['lcdmessage'] = Gtk.Label()
+        self.labels['lcdmessage'].set_halign(Gtk.Align.START)
+        self.labels['lcdmessage'].set_vexpand(False)
+        self.labels['lcdmessage'].get_style_context().add_class("printing-status")
 
         fi_box.add(self.labels['file']) #, True, True, 0)
         fi_box.add(self.labels['status']) #, True, True, 0)
+        fi_box.add(self.labels['lcdmessage']) #, True, True, 0)
         fi_box.set_valign(Gtk.Align.CENTER)
 
         info = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
@@ -376,6 +381,10 @@ class JobStatusPanel(ScreenPanel):
 
         ps = self._printer.get_stat("print_stats")
         vsd = self._printer.get_stat("virtual_sdcard")
+        msg = self._printer.get_stat("display_status")
+        if "message" in msg:
+            if msg['message'] is not None:
+                self.update_message()
 
         if "print_stats" in data and "filename" in data['print_stats']:
             if data['print_stats']['filename'] != self.filename and self.state not in  ["cancelling","cancelled","complete"]:
@@ -588,6 +597,9 @@ class JobStatusPanel(ScreenPanel):
 
     def update_progress (self):
         self.labels['progress_text'].set_text("%s%%" % (str( min(int(self.progress*100),100) )))
+    def update_message (self):
+        msg = self._printer.get_stat("display_status")
+        self.labels['lcdmessage'].set_text("%s" % (msg['message']))
 
     #def update_temp(self, dev, temp, target):
     #    if dev in self.labels:

--- a/screen.py
+++ b/screen.py
@@ -230,7 +230,7 @@ class KlipperScreen(Gtk.Window):
                 "configfile": ["config"],
                 "display_status": ["progress","message"],
                 "fan": ["speed"],
-                "gcode_move": ["extrude_factor","gcode_position","homing_origin","speed_factor"],
+                "gcode_move": ["extrude_factor","gcode_position","homing_origin","speed_factor","speed"],
                 "idle_timeout": ["state"],
                 "pause_resume": ["is_paused"],
                 "print_stats": ["print_duration","total_duration","filament_used","filename","state","message"],

--- a/screen.py
+++ b/screen.py
@@ -41,6 +41,7 @@ PRINTER_BASE_STATUS_OBJECTS = [
     'bed_mesh',
     'idle_timeout',
     'configfile',
+    'display_status',
     'gcode_move',
     'fan',
     'toolhead',
@@ -227,6 +228,7 @@ class KlipperScreen(Gtk.Window):
             "objects": {
                 "bed_mesh": ["profile_name","mesh_max","mesh_min","probed_matrix"],
                 "configfile": ["config"],
+                "display_status": ["progress","message"],
                 "fan": ["speed"],
                 "gcode_move": ["extrude_factor","gcode_position","homing_origin","speed_factor"],
                 "idle_timeout": ["state"],


### PR DESCRIPTION
Removed current G-code move X and Y coordinates, moved Z coordinate to the left, added current G-code speed in mm/s to the right.

JobStatus panel now looks like this:
![telegram-cloud-photo-size-2-5247246783900398503-y](https://user-images.githubusercontent.com/6938996/117708596-ac7f2c80-b1d8-11eb-974a-c4fa66893828.jpg)

