### PR TITLE
Graphical fix for splash_screen

### DIFF
--- a/panels/splash_screen.py
+++ b/panels/splash_screen.py
@@ -22,12 +22,13 @@ class SplashScreenPanel(ScreenPanel):
     def initialize(self, panel_name):
         _ = self.lang.gettext
 
-        image = self._gtk.Image("klipper.svg", None, 4, 3)
+        image = self._gtk.Image("klipper.svg", None, 3.2, 3.2)
 
         self.labels['text'] = Gtk.Label(_("Initializing printer..."))
         self.labels['text'].set_line_wrap(True)
         self.labels['text'].set_line_wrap_mode(Pango.WrapMode.WORD_CHAR)
         self.labels['text'].set_halign(Gtk.Align.CENTER)
+        self.labels['text'].set_valign(Gtk.Align.CENTER)
 
 
         self.labels['actions'] = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
@@ -37,10 +38,10 @@ class SplashScreenPanel(ScreenPanel):
         self.labels['actions'].set_margin_end(20)
 
 
-        main = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=15)
-        main.pack_start(image, True, True, 10)
-        main.pack_end(self.labels['actions'], False, False, 10)
-        main.pack_end(self.labels['text'], True, True, 10)
+        main = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
+        main.pack_start(image, True, True, 0)
+        main.pack_end(self.labels['actions'], False, False, 0)
+        main.pack_end(self.labels['text'], True, True, 0)
 
         self.content.add(main)
         #self.layout.put(box, 0, 0)


### PR DESCRIPTION
Current master:
![2021-06-24-105635_480x320_scrot](https://user-images.githubusercontent.com/1247237/123283231-9657d200-d4e1-11eb-8eea-f95b1bf4d64e.png)

Using bigger fonts
![2021-06-24-105848_480x320_scrot](https://user-images.githubusercontent.com/1247237/123283237-98ba2c00-d4e1-11eb-9caf-64b2a9d9e640.png)

This PR
![2021-06-24-110345_480x320_scrot](https://user-images.githubusercontent.com/1247237/123283258-9c4db300-d4e1-11eb-960b-9e4a5fdb1089.png)

This PR using bigger fonts
![2021-06-24-110320_480x320_scrot](https://user-images.githubusercontent.com/1247237/123283242-99eb5900-d4e1-11eb-87cb-97e7d552d600.png)

the logo was stretched for some reason, i think i forgot to change it when i made the svg