### PR TITLE
job_status more space for info

### DIFF
--- a/panels/job_status.py
+++ b/panels/job_status.py
@@ -186,8 +186,8 @@ class JobStatusPanel(ScreenPanel):
         self.labels['i2_box'].get_style_context().add_class("printing-info-box")
         self.labels['i2_box'].set_valign(Gtk.Align.CENTER)
         self.labels['info_grid'] = self._gtk.HomogeneousGrid()
-        self.labels['info_grid'].attach(self.labels['i1_box'], 0, 0, 1, 1)
-        self.labels['info_grid'].attach(self.labels['i2_box'], 1, 0, 1, 1)
+        self.labels['info_grid'].attach(self.labels['i1_box'], 0, 0, 2, 1)
+        self.labels['info_grid'].attach(self.labels['i2_box'], 2, 0, 3, 1)
 
         grid.attach(overlay, 0, 0, 1, 1)
         grid.attach(fi_box, 1, 0, 3, 1)


### PR DESCRIPTION
to address #190 i reduced the space dedicated for the thumbnail, which was more than enough

master
![2021-06-24-205810_480x320_scrot](https://user-images.githubusercontent.com/1247237/123348664-b615e700-d52f-11eb-95c6-2f39138469d9.png)

this PR
![2021-06-24-205902_480x320_scrot](https://user-images.githubusercontent.com/1247237/123348678-b6ae7d80-d52f-11eb-8d3a-e7373b26e4c4.png)
