### PR TITLE
Fixed bug KlipperScreen ignoring moonraker_api_key configuration.

### DIFF
--- a/ks_includes/config.py
+++ b/ks_includes/config.py
@@ -125,7 +125,7 @@ class KlipperScreenConfig:
                 }
             })
 
-        conf_printers_debug = self.printers.copy()
+        conf_printers_debug = self.printers.deepcopy()
         for printer in conf_printers_debug:
             name = list(printer)[0]
             item = conf_printers_debug[conf_printers_debug.index(printer)]

--- a/ks_includes/config.py
+++ b/ks_includes/config.py
@@ -3,6 +3,7 @@ import os
 import logging
 import json
 import re
+import copy
 
 from io import StringIO
 
@@ -125,7 +126,7 @@ class KlipperScreenConfig:
                 }
             })
 
-        conf_printers_debug = self.printers.deepcopy()
+        conf_printers_debug = copy.deepcopy(self.printers)
         for printer in conf_printers_debug:
             name = list(printer)[0]
             item = conf_printers_debug[conf_printers_debug.index(printer)]


### PR DESCRIPTION
Hiding moonraker_api_key on the log turns out overwriting the actual object. This invalidate moonraker_api_key value and make it unusable. 

Signed-off-by: Henky Prayoga <henky.prayoga@callysta-engineering.com>