### PR TITLE
Use klipper_config by default if available

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1,13 +1,27 @@
 # Configuration
 
-KlipperScreen has some configuration options which are outlined below. KlipperScreen will search for a configuration
-file in the following order:
-_${HOME}/KlipperScreen.conf_
-_${KlipperScreen_Directory}/KlipperScreen.conf_
+The configuration options are outlined below:
+
+KlipperScreen will search for a configuration file in the following order:
+
+1. _${HOME}/KlipperScreen.conf_
+2. _${KlipperScreen_Directory}/KlipperScreen.conf_
+3. _${HOME}/klipper_config/KlipperScreen.conf_
 
 If one of those files are found, it will be used over the default configuration. The default configuration will be
-merged with the custom configuration, so if you do not define any menus the default menus will be used.The default
-config is included here: [ks_includes/KlipperScreen.conf](/ks_includes/KlipperScreen.conf)
+merged with the custom configuration, so if you do not define any menus the default menus will be used.
+
+The default config is included here: (do not edit use as reference)
+
+[ks_includes/KlipperScreen.conf](/ks_includes/KlipperScreen.conf)
+
+If no config file is found then a new configuration file will be created in:
+
+_${HOME}/klipper_config/KlipperScreen.conf_
+
+if _klipper_config_ isn't available then:
+
+_${HOME}/KlipperScreen.conf_
 
 ## Include files
 ```
@@ -50,7 +64,7 @@ moonraker_api_key: False
 ```
 
 ## Printer Options
-Multiple printers can be defined, currently only the first one will be used until an update in the near future.
+Multiple printers can be defined
 ```
 # Define printer and name. Name is anything after the first printer word
 [printer Ender 3 Pro]

--- a/ks_includes/config.py
+++ b/ks_includes/config.py
@@ -221,7 +221,9 @@ class KlipperScreenConfig:
         if not path.exists(file):
             file = "%s/%s" % (os.getcwd(), self.configfile_name)
             if not path.exists(file):
-                file = self.default_config_path
+                file = os.path.expanduser("~/") + "klipper_config/%s" % (self.configfile_name)
+                if not path.exists(file):
+                    file = self.default_config_path
 
         logging.info("Found configuration file at: %s" % file)
         return file
@@ -331,14 +333,18 @@ class KlipperScreenConfig:
         if self.config_path != self.default_config_path:
             path = self.config_path
         else:
-            path =  os.path.expanduser("~/KlipperScreen.conf")
+            path = os.path.expanduser("~/")
+            if os.path.exists(path+"klipper_config/"):
+                path =  path + "klipper_config/KlipperScreen.conf"
+            else:
+                path =  path + "KlipperScreen.conf"
 
         try:
             file = open(path, 'w')
             file.write(contents)
             file.close()
         except:
-            logging.error("Error writing configuration file")
+            logging.error("Error writing configuration file in %s" % path)
 
     def set(self, section, name, value):
         self.config.set(section, name, value)


### PR DESCRIPTION
#88 
search for a configuration file in the following order: (This PR adds the 3rd)

1. _${HOME}/KlipperScreen.conf_
2. _${KlipperScreen_Directory}/KlipperScreen.conf_
3. _${HOME}/klipper_config/KlipperScreen.conf_

If no config file is found then a new configuration file will be created in:

_${HOME}/klipper_config/KlipperScreen.conf_

if _klipper_config_ isn't available then:

_${HOME}/KlipperScreen.conf_

this will not force users to move the config files, but encourage new installations to use the klipper_config folder