### PR TITLE
Simple font size selector

### DIFF
--- a/ks_includes/config.py
+++ b/ks_includes/config.py
@@ -134,6 +134,12 @@ class KlipperScreenConfig:
             {"24htime": {"section": "main", "name": _("24 Hour Time"), "type": "binary", "value": "True"}},
             {"side_macro_shortcut": {"section": "main", "name": _("Macro shortcut on sidebar"), "type": "binary",
                 "value": "True", "callback": screen.toggle_macro_shortcut}},
+            {"font_size": {"section": "main", "name": _("Font Size"), "type": "dropdown",
+                "value": "medium", "callback": screen.restart_warning, "options":[
+                    {"name": _("Small"), "value": "small"},
+                    {"name": _("Medium (default)"), "value": "medium"},
+                    {"name": _("Large"), "value": "large"},
+            ]}},
             #{"": {"section": "main", "name": _(""), "type": ""}}
         ]
 

--- a/screen.py
+++ b/screen.py
@@ -428,7 +428,14 @@ class KlipperScreen(Gtk.Window):
         css = open(klipperscreendir + "/styles/%s/style.css" % (self.theme))
         css_data = css.read()
         css.close()
+
         self.font_size = self.gtk.get_font_size()
+        fontsize_type = self._config.get_main_config_option("font_size","medium")
+        if fontsize_type != "medium":
+            if fontsize_type == "small":
+                self.font_size = round(self.font_size * 0.91)
+            elif (fontsize_type == "large"):
+                self.font_size = round(self.font_size * 1.09)
         css_data = css_data.replace("KS_FONT_SIZE",str(self.font_size))
 
         style_provider = Gtk.CssProvider()


### PR DESCRIPTION
Fix #133 
The difference is quite noticeable in all tested resolutions, here some samples from the two extremes

at 480x320 it ranges from 9px to 12px
![2021-09-08-203659_480x320_scrot](https://user-images.githubusercontent.com/1247237/132599302-6f527aea-a1e5-430a-9e3b-c81badcb830b.png)
![2021-09-08-203736_480x320_scrot](https://user-images.githubusercontent.com/1247237/132599304-8edcb14e-3050-4f45-a796-254623ab2d0f.png)

and at 1080p ranges from 34px small  to 40px large
![2021-09-08-203409_1920x1080_scrot](https://user-images.githubusercontent.com/1247237/132599298-1927c015-ca26-4479-8ed2-761a22e86fc4.png)
![2021-09-08-203341_1920x1080_scrot](https://user-images.githubusercontent.com/1247237/132599294-26a3da3a-ea22-47fe-a0ab-19c8bdc3ab17.png)