### PR TITLE
Allow gcode commands with preheat options

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -86,6 +86,8 @@ z_babystep_values: 0.01, 0.05
 bed: 40
 # Temperature for the tools
 extruder: 195
+# optional GCode to run when the option is selected
+gcode: MY_HEATSOAK_MACRO
 ```
 
 ## Menu

--- a/ks_includes/config.py
+++ b/ks_includes/config.py
@@ -406,6 +406,7 @@ class KlipperScreenConfig:
         item = {
             "extruder": cfg.getint("extruder", 0),
             "bed": cfg.getint("bed", 0),
-            "heater_generic": cfg.getint("heater_generic", 0)
+            "heater_generic": cfg.getint("heater_generic", 0),
+            "gcode": cfg.get("gcode", None)
         }
         return item

--- a/panels/preheat.py
+++ b/panels/preheat.py
@@ -131,6 +131,9 @@ class PreheatPanel(ScreenPanel):
                                                       self.preheat_options[setting]["extruder"])
                 self._printer.set_dev_stat(heater, "target", int(self.preheat_options[setting]["extruder"]))
 
+        if self.preheat_options[setting]['gcode']:
+            self._screen._ws.klippy.gcode_script(self.preheat_options[setting]['gcode'])
+
     def process_update(self, action, data):
         if action != "notify_status_update":
             return


### PR DESCRIPTION
I use this to run a heatsoak macro during preheat.
  It moves to bed center, maxes the part cooling fan,
  and starts my nevermore chamber filter to circulate
  more air.