### PR TITLE
Fix Zcalibrate showing when there is no probe

### DIFF
--- a/ks_includes/defaults.conf
+++ b/ks_includes/defaults.conf
@@ -138,7 +138,7 @@ enable: {{ printer.bed_mesh is defined }}
 name: {{ gettext('Z Calibrate') }}
 icon: z-farther
 panel: zcalibrate
-enable: {{ ((printer.bltouch is defined) or (printer.probe is defined)) }}
+enable: {{ ((printer.bltouch != False) or (printer.probe != False)) }}
 
 [menu __main config limits]
 name: {{ gettext('Limits') }}


### PR DESCRIPTION
This fixes #263 the section is always defined but could be False if there is no probe