### PR TITLE
Configurable xy position for z-calibrate added

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -62,6 +62,15 @@ moonraker_api_key: False
 z_babystep_values: 0.01, 0.05
 ```
 
+## Z probe calibrate Option
+If for any reason the XYZ home position is not suitable for calibrating the probe Z offset, you can enter the coordinates for the desired position here.
+```
+[z_calibrate_position]
+# The specified positions must be> 0 otherwise this option is ignored.
+# the center of the print bed is a good value
+calibrate_x_position: 100
+calibrate_y_position: 100
+```
 
 ## Preheat Options
 ```

--- a/panels/zcalibrate.py
+++ b/panels/zcalibrate.py
@@ -86,8 +86,8 @@ class ZCalibratePanel(ScreenPanel):
             self._screen._ws.klippy.gcode_script(KlippyGcodes.HOME)
         x_position = self._config.get_config()['z_calibrate_position'].getint("calibrate_x_position", 0)
         y_position = self._config.get_config()['z_calibrate_position'].getint("calibrate_y_position", 0)
-        if x_position > 0 and y_position  > 0:
-            self._screen._ws.klippy.gcode_script('G0 X%d Y%d F3000' % (x_position,y_position)) 
+        if x_position > 0 and y_position > 0:
+            self._screen._ws.klippy.gcode_script('G0 X%d Y%d F3000' % (x_position, y_position))
         self._screen._ws.klippy.gcode_script(KlippyGcodes.PROBE_CALIBRATE)
 
     def process_update(self, action, data):

--- a/panels/zcalibrate.py
+++ b/panels/zcalibrate.py
@@ -84,6 +84,10 @@ class ZCalibratePanel(ScreenPanel):
     def activate(self):
         if self._screen.printer.get_stat("toolhead", "homed_axes") != "xyz":
             self._screen._ws.klippy.gcode_script(KlippyGcodes.HOME)
+        x_position = self._config.get_config()['z_calibrate_position'].getint("calibrate_x_position", 0)
+        y_position = self._config.get_config()['z_calibrate_position'].getint("calibrate_y_position", 0)
+        if x_position > 0 and y_position  > 0:
+            self._screen._ws.klippy.gcode_script('G0 X%d Y%d F3000' % (x_position,y_position)) 
         self._screen._ws.klippy.gcode_script(KlippyGcodes.PROBE_CALIBRATE)
 
     def process_update(self, action, data):


### PR DESCRIPTION
Configurable xy position for z-calibrate added

Example for the KlipperScreen.conf
[z_calibrate_position]
calibrate_x_position: 100
calibrate_y_position: 100
