### PR TITLE
Switch from vext.gi to PyGObject

### DIFF
--- a/scripts/KlipperScreen-install.sh
+++ b/scripts/KlipperScreen-install.sh
@@ -4,9 +4,10 @@ SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 KSPATH=$(sed 's/\/scripts//g' <<< $SCRIPTPATH)
 KSENV="${HOME}/.KlipperScreen-env"
 
-PKGLIST="xserver-xorg-video-fbturbo xdotool xinit xinput x11-xserver-utils libopenjp2-7 python3-distutils python3-gi"
-PKGLIST="${PKGLIST} python3-gi-cairo python3-virtualenv gir1.2-gtk-3.0 virtualenv matchbox-keyboard wireless-tools"
+PKGLIST="xserver-xorg-video-fbturbo xdotool xinit xinput x11-xserver-utils libopenjp2-7 python3-distutils"
+PKGLIST="${PKGLIST} python3-virtualenv virtualenv matchbox-keyboard wireless-tools"
 PKGLIST="${PKGLIST} libatlas-base-dev fonts-freefont-ttf"
+PKGLIST="${PKGLIST} libgirepository1.0-dev gcc libcairo2-dev pkg-config python3-dev gir1.2-gtk-3.0"
 
 Red='\033[0;31m'
 Green='\033[0;32m'

--- a/scripts/KlipperScreen-requirements.txt
+++ b/scripts/KlipperScreen-requirements.txt
@@ -3,6 +3,6 @@ jinja2==3.0.3
 matplotlib==3.4.3
 netifaces==0.11.0
 requests==2.26.0
-vext==0.7.6
 websocket-client==1.2.1
-vext.gi==0.7.4 --prefer-binary
+pycairo==1.20.1
+PyGObject==3.42.0


### PR DESCRIPTION
Vext is a workaround, and the native PyGObject seems to work fine for KlipperScreen
Also close #302 (which should have been closed by the previous pr but i forgot the keyword)