### PR TITLE
Support multiple power devices.

### DIFF
--- a/panels/splash_screen.py
+++ b/panels/splash_screen.py
@@ -71,7 +71,7 @@ class SplashScreenPanel(ScreenPanel):
         logging.debug("Power devices: %s" % devices)
         if len(devices) > 0:
             logging.debug("Adding power button")
-            self.labels['power'].connect("clicked", self.power_on, devices[0])
+            self.labels['power'].connect("clicked", self.power_on, devices)
             self.labels['actions'].add(self.labels['power'])
 
         self.labels['actions'].add(self.labels['restart'])
@@ -82,8 +82,9 @@ class SplashScreenPanel(ScreenPanel):
     def firmware_restart(self, widget):
         self._screen._ws.klippy.restart_firmware()
 
-    def power_on(self, widget, device):
-        self._screen._ws.klippy.power_device_on(device)
+    def power_on(self, widget, devices):
+        for device in devices:
+            self._screen._ws.klippy.power_device_on(device)
 
     def restart(self, widget):
         self._screen._ws.klippy.restart()


### PR DESCRIPTION
We've already got an array of device names...why not turn them all on if they have "printer" in the name??