### PR TITLE
Fix configuration filename

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-Create a blank file in `~/klipper_config/KlipperScreen.conf_`, if the file already exist then just edit it.
+Create a blank file in `~/klipper_config/KlipperScreen.conf`, if the file already exist then just edit it.
 
 Write in the file only the options that need to be changed.
 


### PR DESCRIPTION
A rogue underscore (old formatting?) had been appended to the end of the config filename.  Removed the trailing underscore.