### PR TITLE
Support the "enter" key from a physical keyboard

### DIFF
--- a/panels/console.py
+++ b/panels/console.py
@@ -52,7 +52,7 @@ class ConsolePanel(ScreenPanel):
         entry.set_vexpand(False)
         entry.connect("focus-in-event", self._show_keyboard)
         entry.connect("activate", self._send_command)
-        
+
         enter = self._gtk.Button("Send")
         enter.set_hexpand(False)
         enter.connect("clicked", self._send_command)

--- a/panels/console.py
+++ b/panels/console.py
@@ -51,7 +51,8 @@ class ConsolePanel(ScreenPanel):
         entry.set_hexpand(True)
         entry.set_vexpand(False)
         entry.connect("focus-in-event", self._show_keyboard)
-
+        entry.connect("activate", self._send_command)
+        
         enter = self._gtk.Button("Send")
         enter.set_hexpand(False)
         enter.connect("clicked", self._send_command)


### PR DESCRIPTION
I often have a usb keyboard dangling from my printer, and got annoyed I couldn't just hit enter from the console.

https://docs.gtk.org/gtk3/signal.Entry.activate.html