### PR TITLE
Splash_screen: show full error messge

### DIFF
--- a/ks_includes/printer.py
+++ b/ks_includes/printer.py
@@ -115,11 +115,11 @@ class Printer:
 
     def evaluate_state(self):
         wh_state = self.data['webhooks']['state'].lower()  # possible values: startup, ready, shutdown, error
-        idle_state = self.data['idle_timeout']['state'].lower()  # possible values: Idle, printing, ready
-        print_state = self.data['print_stats']['state'].lower()  # possible values: complete, paused, printing, standby
 
         if wh_state == "ready":
             new_state = "ready"
+            print_state = self.data['print_stats']['state'].lower()  # complete, paused, printing, standby
+            idle_state = self.data['idle_timeout']['state'].lower()  # idle, printing, ready
             if print_state == "paused":
                 new_state = "paused"
             elif idle_state == "printing":

--- a/panels/splash_screen.py
+++ b/panels/splash_screen.py
@@ -37,10 +37,20 @@ class SplashScreenPanel(ScreenPanel):
         self.labels['actions'].set_halign(Gtk.Align.CENTER)
         self.labels['actions'].set_homogeneous(True)
 
+        scroll = Gtk.ScrolledWindow()
+        scroll.set_property("overlay-scrolling", False)
+        scroll.set_hexpand(True)
+        scroll.set_vexpand(True)
+        scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        scroll.add(self.labels['text'])
+
+        info = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=0)
+        info.pack_start(image, False, True, 8)
+        info.pack_end(scroll, True, True, 8)
+
         main = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
-        main.pack_start(image, True, True, 0)
+        main.pack_start(info, True, True, 8)
         main.pack_end(self.labels['actions'], False, False, 0)
-        main.pack_end(self.labels['text'], True, True, 0)
 
         self.content.add(main)
 

--- a/screen.py
+++ b/screen.py
@@ -689,14 +689,16 @@ class KlipperScreen(Gtk.Window):
         if "FIRMWARE_RESTART" in msg:
             self.printer_initializing(
                 _("Klipper has encountered an error.\nIssue a FIRMWARE_RESTART to attempt fixing the issue.")
+                + "\n\n" + msg
             )
         elif "micro-controller" in msg:
             self.printer_initializing(
                 _("Klipper has encountered an error with the micro-controller.\nPlease recompile and flash.")
+                + "\n\n" + msg
             )
         else:
             self.printer_initializing(
-                _("Klipper has encountered an error.")
+                _("Klipper has encountered an error.") + "\n\n" + msg
             )
 
         for panel in list(self.panels):


### PR DESCRIPTION
Even if the string is not translated, it helps a lot, the error is on a scrolled window, so any error despcrition length is allowed

![2021-12-29-145050_480x320_scrot](https://user-images.githubusercontent.com/1247237/147690821-94b81ee5-7968-43ea-88e8-268da144f285.png)
![2021-12-29-145130_480x320_scrot](https://user-images.githubusercontent.com/1247237/147690824-5f4a9f85-5fde-452c-abe7-88e3c6058c2c.png)
![2021-12-29-145500_480x320_scrot](https://user-images.githubusercontent.com/1247237/147690825-67bc3d4c-546f-4660-b7c0-77e4712c806f.png)