### PR TITLE
Increase max speed and separate XY and Z max speed

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -51,6 +51,12 @@ moonraker_api_key: False
 
 # Define the z_babystep intervals in a CSV list. Currently only 2 are supported
 z_babystep_values: 0.01, 0.05
+
+# Override the movement speed and set a specific for this printer.
+# These setting overrides the settings configured in the UI. If specified,
+# the values configured in the UI will not be used.
+move_speed_xy: 500
+move_speed_z: 300
 ```
 
 ## Z probe calibrate Option

--- a/ks_includes/config.py
+++ b/ks_includes/config.py
@@ -114,9 +114,12 @@ class KlipperScreenConfig:
                           "callback": screen.restart_warning, "options": [
                               {"name": _("System") + " " + _("(default)"), "value": "system_lang"}
             ]}},
-            {"move_speed": {
-                "section": "main", "name": _("Move Speed (mm/s)"), "type": "scale", "value": "20",
-                "range": [5, 100], "step": 1}},
+            {"move_speed_xy": {
+                "section": "main", "name": _("XY Move Speed (mm/s)"), "type": "scale", "value": "20",
+                "range": [5, 500], "step": 1}},
+            {"move_speed_z": {
+                "section": "main", "name": _("Z Move Speed (mm/s)"), "type": "scale", "value": "20",
+                "range": [5, 500], "step": 1}},
             {"print_sort_dir": {"section": "main", "type": None, "value": "name_asc"}},
             {"print_estimate_method": {
                 "section": "main", "name": _("Estimated Time Method"), "type": "dropdown",
@@ -162,7 +165,7 @@ class KlipperScreenConfig:
         t_path = os.path.join(klipperscreendir, 'styles')
         themes = [d for d in os.listdir(t_path) if (not os.path.isfile(os.path.join(t_path, d)) and d != "z-bolt")]
         themes.sort()
-        theme_opt = self.configurable_options[8]['theme']['options']
+        theme_opt = self.configurable_options[9]['theme']['options']
 
         for theme in themes:
             theme_opt.append({"name": theme, "value": theme})

--- a/ks_includes/config.py
+++ b/ks_includes/config.py
@@ -116,10 +116,10 @@ class KlipperScreenConfig:
             ]}},
             {"move_speed_xy": {
                 "section": "main", "name": _("XY Move Speed (mm/s)"), "type": "scale", "value": "20",
-                "range": [5, 500], "step": 1}},
+                "range": [5, 200], "step": 1}},
             {"move_speed_z": {
                 "section": "main", "name": _("Z Move Speed (mm/s)"), "type": "scale", "value": "20",
-                "range": [5, 500], "step": 1}},
+                "range": [5, 200], "step": 1}},
             {"print_sort_dir": {"section": "main", "type": None, "value": "name_asc"}},
             {"print_estimate_method": {
                 "section": "main", "name": _("Estimated Time Method"), "type": "dropdown",

--- a/panels/move.py
+++ b/panels/move.py
@@ -143,7 +143,15 @@ class MovePanel(ScreenPanel):
         dist = str(self.distance) if dir == "+" else "-" + str(self.distance)
         config_key = "move_speed_z" if axis == AXIS_Z else "move_speed_xy"
 
-        speed = self._config.get_config()['main'].getint(config_key, 20)
+        speed = None
+        printer_cfg = self._config.get_printer_config(self._screen.connected_printer)
+
+        if printer_cfg is not None:
+            speed = printer_cfg.getint(config_key, None)
+        
+        if speed is None:
+            speed = self._config.get_config()['main'].getint(config_key, 20)
+
         speed = max(1, speed)
 
         self._screen._ws.klippy.gcode_script(

--- a/panels/move.py
+++ b/panels/move.py
@@ -148,7 +148,7 @@ class MovePanel(ScreenPanel):
 
         if printer_cfg is not None:
             speed = printer_cfg.getint(config_key, None)
-        
+
         if speed is None:
             speed = self._config.get_config()['main'].getint(config_key, 20)
 

--- a/panels/move.py
+++ b/panels/move.py
@@ -7,6 +7,10 @@ from gi.repository import Gtk, Gdk, GLib
 from ks_includes.KlippyGcodes import KlippyGcodes
 from ks_includes.screen_panel import ScreenPanel
 
+AXIS_X = "X"
+AXIS_Y = "Y"
+AXIS_Z = "Z"
+
 def create_panel(*args):
     return MovePanel(*args)
 
@@ -22,19 +26,19 @@ class MovePanel(ScreenPanel):
         grid.set_column_homogeneous(True)
 
         self.labels['x+'] = self._gtk.ButtonImage("arrow-right", _("X+"), "color1")
-        self.labels['x+'].connect("clicked", self.move, "X", "+")
+        self.labels['x+'].connect("clicked", self.move, AXIS_X, "+")
         self.labels['x-'] = self._gtk.ButtonImage("arrow-left", _("X-"), "color1")
-        self.labels['x-'].connect("clicked", self.move, "X", "-")
+        self.labels['x-'].connect("clicked", self.move, AXIS_X, "-")
 
         self.labels['y+'] = self._gtk.ButtonImage("arrow-up", _("Y+"), "color2")
-        self.labels['y+'].connect("clicked", self.move, "Y", "+")
+        self.labels['y+'].connect("clicked", self.move, AXIS_Y, "+")
         self.labels['y-'] = self._gtk.ButtonImage("arrow-down", _("Y-"), "color2")
-        self.labels['y-'].connect("clicked", self.move, "Y", "-")
+        self.labels['y-'].connect("clicked", self.move, AXIS_Y, "-")
 
         self.labels['z+'] = self._gtk.ButtonImage("z-farther", _("Z+"), "color3")
-        self.labels['z+'].connect("clicked", self.move, "Z", "+")
+        self.labels['z+'].connect("clicked", self.move, AXIS_Z, "+")
         self.labels['z-'] = self._gtk.ButtonImage("z-closer", _("Z-"), "color3")
-        self.labels['z-'].connect("clicked", self.move, "Z", "-")
+        self.labels['z-'].connect("clicked", self.move, AXIS_Z, "-")
 
         self.labels['home'] = self._gtk.ButtonImage("home", _("Home All"), "color4")
         self.labels['home'].connect("clicked", self.home)
@@ -137,8 +141,11 @@ class MovePanel(ScreenPanel):
             dir = "-" if dir == "+" else "+"
 
         dist = str(self.distance) if dir == "+" else "-" + str(self.distance)
-        speed = self._config.get_config()['main'].getint("move_speed", 20)
-        speed = min(max(1, speed), 200)  # Cap movement speed between 1-200mm/s
+        config_key = "move_speed_z" if axis == AXIS_Z else "move_speed_xy"
+
+        speed = self._config.get_config()['main'].getint(config_key, 20)
+        speed = max(1, speed)
+
         self._screen._ws.klippy.gcode_script(
             "%s\n%s %s%s F%s%s" % (
                 KlippyGcodes.MOVE_RELATIVE, KlippyGcodes.MOVE, axis, dist, speed*60,


### PR DESCRIPTION
This change will increase the maximum speed for XY moves to 500 and gives an option to set the maximum speed for Z moves.

Ideally the maximum speed would be read from Klipper `max_velocity` and `max_z_velocity`. Maybe as an enhancement to this change.