### PR TITLE
Temp_panel: put devices in a scroll

### DIFF
--- a/ks_includes/printer.py
+++ b/ks_includes/printer.py
@@ -188,7 +188,7 @@ class Printer:
 
     def get_fans(self):
         fans = ["fan"] if len(self.get_config_section_list("fan")) > 0 else []
-        fan_types = ["controller_fan", "fan_generic", "heater_fan", "temperature_fan"]
+        fan_types = ["controller_fan", "fan_generic", "heater_fan"]
         for type in fan_types:
             for f in self.get_config_section_list("%s " % type):
                 fans.append(f)

--- a/panels/temperature.py
+++ b/panels/temperature.py
@@ -358,10 +358,17 @@ class TemperaturePanel(ScreenPanel):
         da.set_vexpand(True)
         self.labels['da'] = da
 
+        scroll = Gtk.ScrolledWindow()
+        scroll.set_property("overlay-scrolling", False)
+        scroll.set_hexpand(True)
+        scroll.set_vexpand(True)
+        scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        scroll.add(self.labels['devices'])
+
         box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
         box.set_vexpand(True)
-        box.add(self.labels['devices'])
-        box.add(da)
+        box.add(scroll)
+        box.add(self.labels['da'])
 
 
         self.labels['graph_settemp'] = self._gtk.Button(label=_("Set Temp"))
@@ -377,9 +384,10 @@ class TemperaturePanel(ScreenPanel):
         popover.set_position(Gtk.PositionType.BOTTOM)
         self.labels['popover'] = popover
 
-        for d in self._printer.get_temp_store_devices():
+        for i, d in enumerate(self._printer.get_temp_store_devices(), start=3):
             self.add_device(d)
-
+        graph_height = max(0, self._screen.height - (i * 6 * self._gtk.get_font_size()))
+        self.labels['da'].set_size_request(0, graph_height)
         return box
 
 

--- a/panels/temperature.py
+++ b/panels/temperature.py
@@ -337,7 +337,7 @@ class TemperaturePanel(ScreenPanel):
             self._screen._ws.klippy.set_temp_fan_temp(" ".join(self.active_heater.split(" ")[1:]), temp)
         else:
             logging.info("Unknown heater: %s" % self.active_heater)
-            self._screen.show_popup_message(_("Unknown Heater ") + self.active_heater)
+            self._screen.show_popup_message(_("Unknown Heater") + self.active_heater)
         self._printer.set_dev_stat(self.active_heater, "target", temp)
 
     def create_left_panel(self):

--- a/styles/base.css
+++ b/styles/base.css
@@ -262,6 +262,7 @@ trough {
 .heater-grid label {
     margin-top: .3em;
     margin-bottom: .3em;
+    min-height: 2em;
 }
 
 .message_popup {

--- a/styles/base.css
+++ b/styles/base.css
@@ -256,12 +256,12 @@ trough {
 }
 
 .heater-grid {
-    margin-right: .5em;
+    margin-right: .1em;
 }
 
 .heater-grid label {
-    margin-top: .3em;
-    margin-bottom: .3em;
+    margin-top: .2em;
+    margin-bottom: .2em;
     min-height: 2em;
 }
 


### PR DESCRIPTION
This way we can support unlimited devices, also avoids squishing the graph too much and makes the device button a bit larger so it's easier to press

master
![2022-01-13-104354_800x480_scrot](https://user-images.githubusercontent.com/1247237/149342549-f2a19d52-6cc5-4334-9af1-b030bad63edf.png)
pr
![2022-01-13-105019_800x480_scrot](https://user-images.githubusercontent.com/1247237/149342555-d14d80de-e5c4-4cf2-aa0e-07b75dd0a404.png)

Also Fix #429 