### PR TITLE
Group timers for CPU efficiency

### DIFF
--- a/ks_includes/files.py
+++ b/ks_includes/files.py
@@ -98,7 +98,7 @@ class KlippyFiles():
         if filename in self.filelist:
             logging.info("File already exists: %s" % filename)
             self.request_metadata(filename)
-            GLib.timeout_add(1000, self.run_callbacks, mods=[filename])
+            GLib.timeout_add_seconds(1, self.run_callbacks, mods=[filename])
             return
 
         self.filelist.append(filename)

--- a/panels/job_status.py
+++ b/panels/job_status.py
@@ -234,7 +234,7 @@ class JobStatusPanel(ScreenPanel):
         self.show_buttons_for_state()
 
         if self.timeout is None:
-            GLib.timeout_add(500, self.state_check)
+            GLib.timeout_add_seconds(1, self.state_check)
 
     def add_labels(self):
         for child in self.labels['i1_box'].get_children():
@@ -276,7 +276,7 @@ class JobStatusPanel(ScreenPanel):
                 GLib.source_remove(to)
                 self.close_timeouts.remove(to)
             if self.timeout is None:
-                self.timeout = GLib.timeout_add(500, self.state_check)
+                self.timeout = GLib.timeout_add_seconds(1, self.state_check)
 
     def resume(self, widget):
         self._screen._ws.klippy.print_resume(self._response_callback, "enable_button", "pause", "cancel")
@@ -349,7 +349,7 @@ class JobStatusPanel(ScreenPanel):
                 GLib.source_remove(to)
                 self.close_timeouts.remove(to)
             if self.timeout is None:
-                GLib.timeout_add(500, self.state_check)
+                GLib.timeout_add_seconds(1, self.state_check)
             self._screen.wake_screen()
             self.state_check()
 
@@ -461,7 +461,7 @@ class JobStatusPanel(ScreenPanel):
             self._screen.wake_screen()
             timeout = self._config.get_main_config().getint("job_complete_timeout", 30)
             if timeout != 0:
-                self.close_timeouts.append(GLib.timeout_add(timeout * 1000, self.close_panel))
+                self.close_timeouts.append(GLib.timeout_add_seconds(timeout, self.close_panel))
             return False
         elif ps['state'] == "error":
             logging.debug("Error!")
@@ -470,7 +470,7 @@ class JobStatusPanel(ScreenPanel):
             self._screen.wake_screen()
             timeout = self._config.get_main_config().getint("job_error_timeout", 0)
             if timeout != 0:
-                self.close_timeouts.append(GLib.timeout_add(timeout * 1000, self.close_panel))
+                self.close_timeouts.append(GLib.timeout_add_seconds(timeout, self.close_panel))
             return False
         elif ps['state'] == "cancelled" or ps['state'] == "standby":
             # Print was cancelled
@@ -478,7 +478,7 @@ class JobStatusPanel(ScreenPanel):
             self._screen.wake_screen()
             timeout = self._config.get_main_config().getint("job_cancelled_timeout", 0)
             if timeout != 0:
-                self.close_timeouts.append(GLib.timeout_add(timeout * 1000, self.close_panel))
+                self.close_timeouts.append(GLib.timeout_add_seconds(timeout, self.close_panel))
             return False
         elif ps['state'] == "paused":
             self.set_state("paused")

--- a/screen.py
+++ b/screen.py
@@ -376,7 +376,7 @@ class KlipperScreen(Gtk.Window):
         self.show_all()
         self.popup_message = box
 
-        GLib.timeout_add(10000, self.close_popup_message)
+        GLib.timeout_add_seconds(10, self.close_popup_message)
 
         return False
 


### PR DESCRIPTION
> The initial starting point of the timer is determined by the implementation and the implementation is expected to group multiple timers together ... The grouping of timers to fire at the same time results in a more power and CPU efficient ... the use of GLib.timeout_add_seconds is preferred over GLib.timeout_add.

https://webreflection.github.io/gjs-documentation/GLib-2.0/GLib.timeout_add_seconds.html