### PR TITLE
bed_mesh: use default profile

### DIFF
--- a/panels/bed_mesh.py
+++ b/panels/bed_mesh.py
@@ -67,7 +67,7 @@ class BedMeshPanel(ScreenPanel):
 
     def activate_mesh(self, profile):
         if profile == "":
-            profile = None
+            profile = "default"
 
         logging.debug("Activating profile: %s %s" % (self.active_mesh, profile))
         if profile != self.active_mesh:


### PR DESCRIPTION
klipper names the profile "default" if the name wasn't provided