### PR TITLE
Support configurations without fans or extruders or temp devices

### DIFF
--- a/ks_includes/defaults.conf
+++ b/ks_includes/defaults.conf
@@ -30,6 +30,7 @@ icon: home
 name: {{ gettext('Temperature') }}
 icon: heat-up
 panel: temperature
+enable: {{ printer.temperature_devices.count > 0 }}
 
 [menu __main actions]
 name: {{ gettext('Actions') }}
@@ -98,11 +99,13 @@ panel: move
 name: {{ gettext('Extrude') }}
 icon: filament
 panel: extrude
+enable: {{ printer.extruders.count > 0 }}
 
 [menu __main actions fan]
 name: {{ gettext('Fan') }}
 icon: fan
 panel: fan
+enable: {{ printer.fans.count > 0 }}
 
 [menu __main actions macros]
 name: {{ gettext('Macros') }}
@@ -180,17 +183,19 @@ name: {{ gettext('Print Control') }}
 name: {{ gettext('Temperature') }}
 icon: heat-up
 panel: temperature
+enable: {{ printer.temperature_devices.count > 0 }}
 
 [menu __print fan]
 name: {{ gettext('Fan') }}
 icon: fan
 panel: fan
+enable: {{ printer.fans.count > 0 }}
 
 [menu __print extrude]
 name: {{ gettext('Extrude') }}
 icon: filament
 panel: extrude
-enable: {{ printer.pause_resume.is_paused == True }}
+enable: {{ (printer.pause_resume.is_paused == True) and (printer.extruders.count > 0) }}
 
 [menu __print power]
 name: {{ gettext('Power') }}

--- a/ks_includes/printer.py
+++ b/ks_includes/printer.py
@@ -32,6 +32,8 @@ class Printer:
         self.config = data['configfile']['config']
         self.toolcount = 0
         self.extrudercount = 0
+        self.tempdevcount = 0
+        self.fancount = 0
         self.tools = []
         self.devices = {}
         self.data = data
@@ -65,6 +67,10 @@ class Printer:
                     "temperature": 0,
                     "target": 0
                 }
+                self.tempdevcount += 1
+            if x == 'fan' or x.startswith('controller_fan ') or x.startswith('heater_fan ') \
+                    or x.startswith('fan_generic '):
+                self.fancount += 1
             if x.startswith('bed_mesh '):
                 r = self.config[x]
                 r['x_count'] = int(r['x_count'])
@@ -77,7 +83,10 @@ class Printer:
         self.process_update(data)
 
         logging.info("Klipper version: %s", self.klipper['version'])
-        logging.info("### Toolcount: " + str(self.toolcount) + " Heaters: " + str(self.extrudercount))
+        logging.info("# Toolcount: %s", str(self.toolcount))
+        logging.info("# Extruders: %s", str(self.extrudercount))
+        logging.info("# Temperature devices: %s", str(self.tempdevcount))
+        logging.info("# Fans: %s", str(self.fancount))
 
     def process_update(self, data):
         keys = [
@@ -212,6 +221,15 @@ class Printer:
     def get_printer_status_data(self):
         data = {
             "printer": {
+                "extruders": {
+                    "count": self.extrudercount
+                },
+                "temperature_devices": {
+                    "count": self.tempdevcount
+                },
+                "fans": {
+                    "count": self.fancount
+                },
                 "bltouch": self.section_exists("bltouch"),
                 "gcode_macros": {
                     "count": len(self.get_gcode_macros())

--- a/panels/base_panel.py
+++ b/panels/base_panel.py
@@ -123,23 +123,20 @@ class BasePanel(ScreenPanel):
         if show is False:
             return
 
-        i = 0
-        for extruder in self._printer.get_tools():
-            self.labels[extruder + '_box'] = Gtk.Box(spacing=0)
-            self.labels[extruder] = Gtk.Label(label="")
-            # self.labels[extruder].get_style_context().add_class("printing-info")
-            if i <= 4:
-                ext_img = self._gtk.Image("extruder-%s.svg" % i, None, .4, .4)
-                self.labels[extruder + '_box'].pack_start(ext_img, True, 3, 3)
-            self.labels[extruder + '_box'].pack_start(self.labels[extruder], True, 3, 3)
-            i += 1
-        self.current_extruder = self._printer.get_stat("toolhead", "extruder")
-        self.control['temp_box'].pack_start(self.labels["%s_box" % self.current_extruder], True, 5, 5)
+        if self._printer.get_tools():
+            for i, extruder in enumerate(self._printer.get_tools()):
+                self.labels[extruder + '_box'] = Gtk.Box(spacing=0)
+                self.labels[extruder] = Gtk.Label(label="")
+                if i <= 4:
+                    ext_img = self._gtk.Image("extruder-%s.svg" % i, None, .4, .4)
+                    self.labels[extruder + '_box'].pack_start(ext_img, True, 3, 3)
+                self.labels[extruder + '_box'].pack_start(self.labels[extruder], True, 3, 3)
+            self.current_extruder = self._printer.get_stat("toolhead", "extruder")
+            self.control['temp_box'].pack_start(self.labels["%s_box" % self.current_extruder], True, 5, 5)
 
         if self._printer.has_heated_bed():
             heater_bed = self._gtk.Image("bed.svg", None, .4, .4)
             self.labels['heater_bed'] = Gtk.Label(label="20 C")
-            # self.labels['heater_bed'].get_style_context().add_class("printing-info")
             heater_bed_box = Gtk.Box(spacing=0)
             heater_bed_box.pack_start(heater_bed, True, 5, 5)
             heater_bed_box.pack_start(self.labels['heater_bed'], True, 3, 3)

--- a/panels/menu.py
+++ b/panels/menu.py
@@ -13,6 +13,7 @@ def create_panel(*args):
 
 class MenuPanel(ScreenPanel):
     i = 0
+    j2_data = None
     def initialize(self, panel_name, display_name, items):
         _ = self.lang.gettext
 
@@ -25,7 +26,8 @@ class MenuPanel(ScreenPanel):
         self.content.add(self.grid)
 
     def activate(self):
-        self.j2_data = self._printer.get_printer_status_data()
+        if not self.j2_data:
+            self.j2_data = self._printer.get_printer_status_data()
         self.j2_data.update({
             'moonraker_connected': self._screen._ws.is_connected()
         })
@@ -94,6 +96,8 @@ class MenuPanel(ScreenPanel):
         if enable is False:
             return False
 
+        if not self.j2_data:
+            self.j2_data = self._printer.get_printer_status_data()
         try:
             logging.debug("Template: '%s'" % enable)
             logging.debug("Data: %s" % self.j2_data)


### PR DESCRIPTION
This allows KS to start without  fans or extruders or temp devices
This PR it's part of #451 separated for a easier review

The issue with the current layout is that the main menu is intended to show temp devices and without them its pointless
![remmina_Pi_192 168 18 99_20220123-004556](https://user-images.githubusercontent.com/1247237/150660247-f8b5ea96-e59f-4604-a536-a28b26e0fe50.png)
![remmina_Pi_192 168 18 99_20220123-004606](https://user-images.githubusercontent.com/1247237/150660248-17a7cc36-635e-41fa-88c9-be0d60aa86e4.png)
