### PR TITLE
base_panel: added light toggle button where back button is used to be…

### DIFF
--- a/panels/base_panel.py
+++ b/panels/base_panel.py
@@ -41,11 +41,10 @@ class BasePanel(ScreenPanel):
         self.control['back'].connect("clicked", self.back)
         self.control['home'] = self._gtk.ButtonImage('main', None, None, button_scale[0], button_scale[1])
         self.control['home'].connect("clicked", self.menu_return, True)
-        
-        # light toggle button
+
         self.control['light'] = self._gtk.ButtonImage('light', None, None, button_scale[0], button_scale[1])
         self.control['light'].connect("clicked", self.light_toggle)
-        
+
         if len(self._config.get_printers()) > 1:
             self.control['printer_select'] = self._gtk.ButtonImage(
                 'shuffle', None, None, button_scale[0], button_scale[1])
@@ -175,7 +174,7 @@ class BasePanel(ScreenPanel):
                 self._screen._menu_go_back()
         else:
             self._screen._menu_go_back()
-            
+
     def light_toggle(self, widget):
         lights = [i for i in self._printer.get_power_devices() if i.lower().startswith('light')]
         logging.debug("Light devices: %s" % lights)
@@ -185,11 +184,11 @@ class BasePanel(ScreenPanel):
             _light_stat = self._printer.power_devices[_light]['status']
             logging.debug("Light device status: %s" % _light_stat)
             # get current state only for 1st light device
-            if light1 == None:
+            if light1 is None:
                 light1 = _light
                 light1_stat = _light_stat
         # swith all light devices to toggled state of device 1
-        for _light in lights:    
+        for _light in lights:
             if light1_stat == "on":
                 self._screen._ws.klippy.power_device_off(_light)
             else:
@@ -230,14 +229,11 @@ class BasePanel(ScreenPanel):
             for i in range(0, 2):
                 self.control_grid.remove(self.control_grid.get_child_at(0, i))
                 self.control_grid.attach(self.control['space%s' % i], 0, i, 1, 1)
-            
-            # light toggle button
             lights_available = [i for i in self._printer.get_power_devices() if i.lower().startswith('light')]
             logging.debug("Light devices: %s" % lights_available)
             if lights_available:
                 logging.debug("adding light button")
                 self.control_grid.attach(self.control['light'], 0, 0, 1, 1)
-            
             self.buttons_showing['back'] = False
         self.control_grid.show()
 


### PR DESCRIPTION
… whenever no back button is displayed (only if a power device starting "light" in it´s name is configured. 
Does not affect original back-button behaviour. 

![KlipperScreen_LightToggleButton](https://user-images.githubusercontent.com/32464995/153769453-1a1474f0-978d-4804-9d42-92a56b80e391.PNG)
)
