### PR TITLE
Show position including offsets in the move panel

### DIFF
--- a/panels/move.py
+++ b/panels/move.py
@@ -115,10 +115,10 @@ class MovePanel(ScreenPanel):
         if action != "notify_status_update":
             return
 
-        if "toolhead" in data and "position" in data["toolhead"]:
-            self.labels['pos_x'].set_text("X: %.2f" % (data["toolhead"]["position"][0]))
-            self.labels['pos_y'].set_text("Y: %.2f" % (data["toolhead"]["position"][1]))
-            self.labels['pos_z'].set_text("Z: %.2f" % (data["toolhead"]["position"][2]))
+        if "gcode_move" in data and "gcode_position" in data["gcode_move"]:
+            self.labels['pos_x'].set_text("X: %.2f" % (data["gcode_move"]["gcode_position"][0]))
+            self.labels['pos_y'].set_text("Y: %.2f" % (data["gcode_move"]["gcode_position"][1]))
+            self.labels['pos_z'].set_text("Z: %.2f" % (data["gcode_move"]["gcode_position"][2]))
 
     def change_distance(self, widget, distance):
         if self.distance == distance:


### PR DESCRIPTION
This makes Z stepping make more sense after applying a Z offset and more
consistent with the results of sending manual gcodes.