### PR TITLE
Fix issues waking up screen under a remote connection

### DIFF
--- a/ks_includes/config.py
+++ b/ks_includes/config.py
@@ -151,6 +151,7 @@ class KlipperScreenConfig:
                                "value": "False"}},
             {"only_heaters": {"section": "main", "name": _("Hide sensors in Temp."), "type": "binary",
                               "value": "False", "callback": screen.restart_warning}},
+            {"use_dpms": {"section": "main", "name": _("Screen DPMS"), "type": "binary", "value": "True"}},
             # {"": {"section": "main", "name": _(""), "type": ""}}
         ]
 

--- a/ks_includes/config.py
+++ b/ks_includes/config.py
@@ -151,7 +151,8 @@ class KlipperScreenConfig:
                                "value": "False"}},
             {"only_heaters": {"section": "main", "name": _("Hide sensors in Temp."), "type": "binary",
                               "value": "False", "callback": screen.restart_warning}},
-            {"use_dpms": {"section": "main", "name": _("Screen DPMS"), "type": "binary", "value": "True"}},
+            {"use_dpms": {"section": "main", "name": _("Screen DPMS"), "type": "binary",
+                          "value": "True", "callback": screen.set_dpms}},
             # {"": {"section": "main", "name": _(""), "type": ""}}
         ]
 

--- a/screen.py
+++ b/screen.py
@@ -636,6 +636,11 @@ class KlipperScreen(Gtk.Window):
             os.system("xset -display :0 dpms force on")
             self.close_screensaver()
 
+    def set_dpms(self, use_dpms):
+        self.use_dpms = use_dpms
+        logging.info("DPMS set to: %s" % self.use_dpms)
+        self.set_screenblanking_timeout(self._config.get_main_config_option('screen_blanking'))
+
     def set_screenblanking_timeout(self, time):
         # The 'blank' flag sets the preference to blank the video
         # rather than display a background pattern

--- a/styles/base.css
+++ b/styles/base.css
@@ -457,6 +457,14 @@ popover button {
     background-color: #222;
 }
 
+.screensaver {
+    background-color: black;
+}
+
+.screensaver button:active {
+    background-color: rgba(0, 0, 0, 0.5);
+}
+
 /* Hardcoded values until creation of dynamic CSS updates */
 .graph_label_hidden {padding-left: .9em;} /* .4em on top of normal button padding */
 .graph_label_extruder {border-left-width: .4em; border-left-style: solid;}


### PR DESCRIPTION
When connected from vnc the screen did not unlock from the remote session click
This also implements an optional disable DPMS for people with issues where DPMS doesn't work as it should (hw issues, driver issues, etc)
Changes #340 almost entirely