### PR TITLE
Added option to select default printer at startup.

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -36,6 +36,9 @@ show_cursor: False
 
 # Allows to define custom systemctl command for restart like xrdp
 service: KlipperScreen
+
+# If multiple printers are defined, this can be set the name of the one to show at startup.
+default_printer: Ender 3 Pro
 ```
 
 ## Printer Options

--- a/screen.py
+++ b/screen.py
@@ -149,9 +149,12 @@ class KlipperScreen(Gtk.Window):
         self.change_cursor()
 
         printers = self._config.get_printers()
-        logging.debug("Printers: %s" % printers)
-        if len(printers) == 1:
-            pname = list(self._config.get_printers()[0])[0]
+        default_printer = self._config.get_main_config().get('default_printer')
+        logging.debug("Printers: %s, Default: %s" % (printers, default_printer))
+        if [True for p in  printers if default_printer in p]:
+            self.connect_printer(default_printer)
+        elif len(printers) == 1:
+            pname = list(printers[0])[0]
             self.connect_printer(pname)
         else:
             self.show_panel("printer_select", "printer_select", "Printer Select", 2)

--- a/screen.py
+++ b/screen.py
@@ -151,7 +151,7 @@ class KlipperScreen(Gtk.Window):
         printers = self._config.get_printers()
         default_printer = self._config.get_main_config().get('default_printer')
         logging.debug("Printers: %s, Default: %s" % (printers, default_printer))
-        if [True for p in  printers if default_printer in p]:
+        if [True for p in printers if default_printer in p]:
             self.connect_printer(default_printer)
         elif len(printers) == 1:
             pname = list(printers[0])[0]


### PR DESCRIPTION
Added a main option to let KlipperScreen start on a default printer at startup, instead of on the printer select screen.