### PR TITLE
Enable users to inject a custom script to start KlipperScreen

### DIFF
--- a/scripts/KlipperScreen-start.sh
+++ b/scripts/KlipperScreen-start.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+SCRIPTPATH=$(dirname $(realpath $0))
+if [ -f $SCRIPTPATH/launch_KlipperScreen.sh ]
+then
+echo "Running "$SCRIPTPATH"/launch_KlipperScreen.sh"
+$SCRIPTPATH/launch_KlipperScreen.sh
+exit $?
+fi
+
+echo "Running KlipperScreen on X in display :0 by default"
+/usr/bin/xinit $KS_XCLIENT

--- a/scripts/KlipperScreen.service
+++ b/scripts/KlipperScreen.service
@@ -9,7 +9,8 @@ Restart=always
 RestartSec=1
 User=KS_USER
 WorkingDirectory=KS_DIR
-ExecStart=/usr/bin/xinit KS_ENV/bin/python KS_DIR/screen.py
+Environment="KS_XCLIENT=KS_ENV/bin/python KS_DIR/screen.py"
+ExecStart="KS_DIR/scripts/KlipperScreen-start.sh"
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/xsdl_wrapper.sh
+++ b/scripts/xsdl_wrapper.sh
@@ -1,0 +1,37 @@
+# A wrapper for the popular script for KlipperScreen on Android over adb over USB.
+# https://klipper.discourse.group/t/how-to-klipperscreen-on-android-smart-phones/1196
+#
+# Keeps the process alive while the server is active
+# to mimic default X's behaviour and keep the service happy
+
+./lauch_klipperscreen.sh
+
+ret=1
+timeout=0
+echo -n "Waiting for X-server to be ready "
+while [ $ret -gt 0 ] && [ $timeout -lt 60 ]
+do
+    xset -display :100 -q > /dev/null 2>&1
+    ret=$?
+    timeout=$( expr $timeout + 1 )
+    echo -n "."
+    sleep 1
+done
+echo ""
+if [ $timeout -lt 60 ]
+then
+echo -n "X server found. Monitoring connection"
+ret=0
+while [ $ret -eq 0 ]
+do
+    xset -display :100 -q > /dev/null 2>&1
+    ret=$?
+    sleep 60
+done
+echo -n "X Server connection lost"
+    exit 0
+
+else
+echo -n "X server not found"
+    exit 1
+fi


### PR DESCRIPTION
Users can create an executable file named `scripts/launch_KlipperScreen.sh` to override the default server command.

A helper script is included to ease migration for the common Android XSDL use-case by having it mimic local X server behaviour (stays resident while the server is responding)

The following one-liner will get them back on deck after the change, by creating the override to the helper script:
`echo "scripts/xsdl_wrapper.sh" > ~/KlipperScreen/scripts/launch_KlipperScreen.sh; chmod +x ~/KlipperScreen/scripts/launch_KlipperScreen.sh`