### PR TITLE
Ignore `include` sections when validating the config

### DIFF
--- a/ks_includes/config.py
+++ b/ks_includes/config.py
@@ -153,6 +153,9 @@ class KlipperScreenConfig:
             elif section.startswith('z_calibrate_position'):
                 # This section may be deprecated in favor of moving this options under the printer section
                 numbers = ('calibrate_x_position', 'calibrate_y_position')
+            elif section.startswith('include'):
+                # We don't need to validate 'include' sections here.
+                continue
             elif section == 'DEFAULT':
                 continue
             else:

--- a/ks_includes/config.py
+++ b/ks_includes/config.py
@@ -114,6 +114,10 @@ class KlipperScreenConfig:
         valid = True
         bools = strs = numbers = ()
         for section in self.config:
+            if section == 'DEFAULT' or section.startswith('include '):
+                # Do not validate 'DEFAULT' or 'include*' sections
+                continue
+
             if section == 'main':
                 bools = (
                     'invert_x', 'invert_y', 'invert_z', '24htime', 'only_heaters', 'show_cursor', 'confirm_estop',
@@ -153,11 +157,6 @@ class KlipperScreenConfig:
             elif section.startswith('z_calibrate_position'):
                 # This section may be deprecated in favor of moving this options under the printer section
                 numbers = ('calibrate_x_position', 'calibrate_y_position')
-            elif section.startswith('include'):
-                # We don't need to validate 'include' sections here.
-                continue
-            elif section == 'DEFAULT':
-                continue
             else:
                 self.errors.append(f'Section [{section}] not recognized')
 


### PR DESCRIPTION
# Minor improvement to `validate_config`


## 1. Don't validate `include` sections.

We need a `continue` here because `include` sections are not 'standard', and don't have any keys to validate.

`include` sections are tangentially validated later via `_include_config()`.

## 2. Move checks for non-validated sections to the start of the loop

If we are currently looking at one of these sections, fail fast and continue as we're not actually going to do
anything.
