### PR TITLE
Fix: Heaters not showing their respective power percentages

### DIFF
--- a/panels/main_menu.py
+++ b/panels/main_menu.py
@@ -251,7 +251,7 @@ class MainPanel(MenuPanel):
                 h,
                 self._printer.get_dev_stat(h, "temperature"),
                 self._printer.get_dev_stat(h, "target"),
-                self._printer.get_dev_stat(x, "power"),
+                self._printer.get_dev_stat(h, "power"),
             )
         return
 

--- a/panels/temperature.py
+++ b/panels/temperature.py
@@ -527,7 +527,7 @@ class TemperaturePanel(ScreenPanel):
                 h,
                 self._printer.get_dev_stat(h, "temperature"),
                 self._printer.get_dev_stat(h, "target"),
-                self._printer.get_dev_stat(x, "power"),
+                self._printer.get_dev_stat(h, "power"),
             )
         return
 


### PR DESCRIPTION
This was probably just a copy & paste mistake by @lalten.

This fixes it by showing the heaters respective power percentages

Fixes #746 