### PR TITLE
Update zcalibrate.py

### DIFF
--- a/panels/zcalibrate.py
+++ b/panels/zcalibrate.py
@@ -142,8 +142,7 @@ class ZCalibratePanel(ScreenPanel):
 
     def start_calibration(self, widget, method):
         self.labels['popover'].popdown()
-        if self._screen.printer.get_stat("toolhead", "homed_axes") != "xyz":
-            self._screen._ws.klippy.gcode_script(KlippyGcodes.HOME)
+        self._screen._ws.klippy.gcode_script(KlippyGcodes.HOME)
 
         if method == "probe":
             self._move_to_position()

--- a/panels/zcalibrate.py
+++ b/panels/zcalibrate.py
@@ -142,7 +142,8 @@ class ZCalibratePanel(ScreenPanel):
 
     def start_calibration(self, widget, method):
         self.labels['popover'].popdown()
-        self._screen._ws.klippy.gcode_script(KlippyGcodes.HOME)
+        if self._screen.printer.get_stat("toolhead", "homed_axes") != "xyz":
+            self._screen._ws.klippy.gcode_script(KlippyGcodes.HOME)
 
         if method == "probe":
             self._move_to_position()


### PR DESCRIPTION
Proposal: If abort is pressed, force auto home to reposition printhead when Z calibrate is restarted. 

Issue: In the case that the user aborts, the machine does not rehome. So, worst case, the printhead is off the bed on custom applications or in a place that the bltouch cannot probe, so when you press Start, it tries to home z in that position and moves below the gantry limits (corexy). Something will bend or break.

Currently, it checks to see if X,Y,Z are homed but doesn't check the current positions. Happy to see it fixed in a more elegant way but simplest thing was to remove the if statement. 