### PR TITLE
Xserver-XSDL cmd args to stop screen blanking

### DIFF
--- a/docs/Android.md
+++ b/docs/Android.md
@@ -73,6 +73,15 @@ sudo service KlipperScreen stop
 sudo service KlipperScreen start
 ```
 
+## Stop Screen Blanking in Xserver-XSDL
+
+Even after enabling the "Stay Awake" option in the Developer/USB Debugging options of your Android device, the Xserver-XSDL may still go to a black screen but keep the backlight of your device on.  To keep the screen always active, upon start up of Xserver-XSDL app, select the `Change Device Configuration` at the top of the splash screen and then select the `Command line parameters, one argument per line` option. Append the following argument (must be on seperate lines):
+```
+-s
+0
+```
+This will disable the screen-saver in Xserver and keep KlipperScreen always active.
+
 ## Migration from other tutorials
 
 KlipperScreen says error option "service" is not supported anymore.


### PR DESCRIPTION
Added documentation to stop Xserver-XSDL from enabling its 5 minute default screen saver and blanking the screen.  In this scenario even after enabling the 'stay away' option in the debugging or developer options of the android device, the screen will still go black, but leave the back light on.  To stop this this, you must disable the Xserver screen saver option in the start up arguments of the server app itself.  I spend more than a few hours looking for and figuring this out, when this little bit of info would have saved me a lot of time.

Not sure if where I placed it is the best place in the doc, but the info is sound.  I am using my android over USB, FYI.