### PR TITLE
Fixed z-bolt images opacity

### DIFF
--- a/styles/z-bolt/images/extruder-0.svg
+++ b/styles/z-bolt/images/extruder-0.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+	xmlns:dc="http://purl.org/dc/elements/1.1/"
+	xmlns:cc="http://creativecommons.org/ns#"
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:svg="http://www.w3.org/2000/svg"
+	xmlns="http://www.w3.org/2000/svg"
+	xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+	xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="64"
    height="64"
    viewBox="0 0 64 64"
@@ -14,21 +14,21 @@
    id="svg10"
    sodipodi:docname="extruder-0.svg"
    inkscape:version="1.0.2 (e86c870879, 2021-01-15, custom)">
-  <metadata
+	<metadata
      id="metadata16">
-    <rdf:RDF>
-      <cc:Work
+		<rdf:RDF>
+			<cc:Work
          rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
+				<dc:format>image/svg+xml</dc:format>
+				<dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title>folder</dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <defs
+				<dc:title>folder</dc:title>
+			</cc:Work>
+		</rdf:RDF>
+	</metadata>
+	<defs
      id="defs14" />
-  <sodipodi:namedview
+	<sodipodi:namedview
      pagecolor="#bfbfbf"
      bordercolor="#666666"
      borderopacity="1"
@@ -43,43 +43,44 @@
      showgrid="false"
      inkscape:pagecheckerboard="false"
      inkscape:zoom="5.4137931"
-     inkscape:cx="38.196925"
-     inkscape:cy="43.755812"
+     inkscape:cx="32.109123"
+     inkscape:cy="22.356606"
      inkscape:window-x="-8"
      inkscape:window-y="-8"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg10"
      inkscape:snap-bbox="true"
      inkscape:snap-bbox-edge-midpoints="true"
-     inkscape:document-rotation="0" />
-  <!-- Generator: Sketch 52.5 (67469) - http://www.bohemiancoding.com/sketch -->
-  <title
+     inkscape:document-rotation="0"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-midpoints="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:bbox-nodes="true"
+     inkscape:bbox-paths="true" />
+	<!-- Generator: Sketch 52.5 (67469) - http://www.bohemiancoding.com/sketch -->
+	<title
      id="title2">folder</title>
-  <desc
+	<desc
      id="desc4">Created with Sketch.</desc>
-  <ellipse
-     id="Oval"
-     stroke="#ffffff"
-     stroke-width="2"
-     cx="32"
-     cy="26.143875"
-     style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke-width:3;stroke-miterlimit:4;stroke-dasharray:none"
-     rx="15.174833"
-     ry="15.226054" />
-  <path
-     d="m 31.999999,36.143876 q -2.761358,0 -4.195655,-1.46604 -1.434299,-1.466039 -1.434299,-4.088769 v -8.890383 q 0,-2.63618 1.434299,-4.088769 1.447701,-1.46604 4.195655,-1.46604 2.761359,0 4.195657,1.45259 1.434299,1.452587 1.434299,4.102219 v 8.890383 q 0,2.63618 -1.447703,4.102219 -1.4343,1.45259 -4.182253,1.45259 z m 0,-2.83793 q 1.367275,0 2.010698,-0.753195 0.656829,-0.766643 0.656829,-2.192333 v -8.433086 q 0,-1.42569 -0.643423,-2.178884 -0.643423,-0.766644 -2.024104,-0.766644 -1.380678,0 -2.024102,0.766644 -0.643423,0.753194 -0.643423,2.178884 v 8.433086 q 0,1.42569 0.643423,2.192333 0.656828,0.753195 2.024102,0.753195 z"
-     id="path866"
-     style="font-weight:500;font-size:26px;font-family:OpenSans-SemiBold, 'Open Sans';fill:#000000;fill-rule:evenodd;stroke:none;stroke-width:1" />
-  <path
-     style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="M 20.327052,56.986395 10.210495,55.034337 V 44.102811 l 2.723688,-3.904116 V 19.897289 l -2.723688,-4.68494 V 5.8424699 L 14.490576,3.5 h 6.614672 l 2.33459,3.1232932 H 40.560162 L 42.894752,3.5 h 6.614672 l 4.280081,2.3424699 v 9.3698791 l -2.723688,4.68494 v 20.301406 l 2.723688,3.904116 V 55.034337 L 43.672948,56.986395 40.560162,53.472691 H 23.439838 l -3.112786,3.513704"
-     id="path943" />
-  <path
-     style="fill:#000000;fill-opacity:0;stroke:#ffffff;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="M 24.996231,58.377 H 39.003769"
-     id="path945" />
-  <path
-     style="fill:#000000;fill-opacity:0;stroke:#ffffff;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="M 29.66541,58.377 32,61.500293 34.334589,58.377"
-     id="path947" />
+	<g>
+		<path fill="#FFFFFF" d="M32,10.918c-8.381,0-15.175,6.817-15.175,15.226c0,8.409,6.794,15.226,15.175,15.226
+		s15.175-6.817,15.175-15.226C47.175,17.735,40.381,10.918,32,10.918z M37.63,30.589c0,1.758-0.482,3.125-1.448,4.103
+		c-0.955,0.969-2.35,1.453-4.182,1.453c-1.841,0-3.239-0.489-4.196-1.467c-0.956-0.977-1.434-2.34-1.434-4.089v-8.89
+		c0-1.757,0.478-3.121,1.434-4.089c0.965-0.978,2.364-1.466,4.196-1.466c1.841,0,3.239,0.484,4.195,1.452
+		c0.957,0.969,1.435,2.336,1.435,4.103V30.589z"/>
+		<path fill="#FFFFFF" d="M32,18.982c-0.92,0-1.595,0.255-2.024,0.767c-0.429,0.502-0.644,1.229-0.644,2.179v8.433
+		c0,0.951,0.214,1.681,0.644,2.192c0.438,0.502,1.112,0.754,2.024,0.754c0.912,0,1.582-0.252,2.011-0.754
+		c0.438-0.511,0.657-1.242,0.657-2.192v-8.433c0-0.95-0.215-1.677-0.645-2.179C33.596,19.237,32.92,18.982,32,18.982z"/>
+	</g>
+	<path id="path943" fill="none" stroke="#FFFFFF" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" d="
+	M20.327,56.986L10.21,55.034V44.104l2.724-3.904V19.897l-2.724-4.685v-9.37l4.28-2.342h6.615l2.334,3.124h17.121L42.895,3.5h6.615
+	l4.279,2.342v9.37l-2.723,4.685v20.302l2.723,3.904v10.931l-10.116,1.952l-3.112-3.514H23.44L20.327,56.986"/>
+	<path id="path945" fill-opacity="0" stroke="#FFFFFF" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" d="
+	M24.996,58.377h14.008"/>
+	<path id="path947" fill-opacity="0" stroke="#FFFFFF" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" d="
+	M29.666,58.377L32,61.5l2.334-3.123"/>
+	<path fill="none" d="z"/>
 </svg>

--- a/styles/z-bolt/images/extruder-1.svg
+++ b/styles/z-bolt/images/extruder-1.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+	xmlns:dc="http://purl.org/dc/elements/1.1/"
+	xmlns:cc="http://creativecommons.org/ns#"
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:svg="http://www.w3.org/2000/svg"
+	xmlns="http://www.w3.org/2000/svg"
+	xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+	xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="64"
    height="64"
    viewBox="0 0 64 64"
@@ -14,21 +14,21 @@
    id="svg10"
    sodipodi:docname="extruder-1.svg"
    inkscape:version="1.0.2 (e86c870879, 2021-01-15, custom)">
-  <metadata
+	<metadata
      id="metadata16">
-    <rdf:RDF>
-      <cc:Work
+		<rdf:RDF>
+			<cc:Work
          rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
+				<dc:format>image/svg+xml</dc:format>
+				<dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title>folder</dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <defs
+				<dc:title>folder</dc:title>
+			</cc:Work>
+		</rdf:RDF>
+	</metadata>
+	<defs
      id="defs14" />
-  <sodipodi:namedview
+	<sodipodi:namedview
      pagecolor="#bfbfbf"
      bordercolor="#666666"
      borderopacity="1"
@@ -43,49 +43,39 @@
      showgrid="false"
      inkscape:pagecheckerboard="false"
      inkscape:zoom="5.4137931"
-     inkscape:cx="38.196925"
-     inkscape:cy="43.755812"
+     inkscape:cx="32.109123"
+     inkscape:cy="22.356606"
      inkscape:window-x="-8"
      inkscape:window-y="-8"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg10"
      inkscape:snap-bbox="true"
      inkscape:snap-bbox-edge-midpoints="true"
-     inkscape:document-rotation="0" />
-  <!-- Generator: Sketch 52.5 (67469) - http://www.bohemiancoding.com/sketch -->
-  <title
+     inkscape:document-rotation="0"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-midpoints="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:bbox-nodes="true"
+     inkscape:bbox-paths="true" />
+	<!-- Generator: Sketch 52.5 (67469) - http://www.bohemiancoding.com/sketch -->
+	<title
      id="title2">folder</title>
-  <desc
+	<desc
      id="desc4">Created with Sketch.</desc>
-  <ellipse
-     id="Oval"
-     stroke="#ffffff"
-     stroke-width="2"
-     cx="32"
-     cy="26.143875"
-     style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke-width:3;stroke-miterlimit:4;stroke-dasharray:none"
-     rx="15.174833"
-     ry="15.226054" />
-  <path
-     style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="M 20.327052,56.986395 10.210495,55.034337 V 44.102811 l 2.723688,-3.904116 V 19.897289 l -2.723688,-4.68494 V 5.8424699 L 14.490576,3.5 h 6.614672 l 2.33459,3.1232932 H 40.560162 L 42.894752,3.5 h 6.614672 l 4.280081,2.3424699 v 9.3698791 l -2.723688,4.68494 v 20.301406 l 2.723688,3.904116 V 55.034337 L 43.672948,56.986395 40.560162,53.472691 H 23.439838 l -3.112786,3.513704"
-     id="path943" />
-  <path
-     style="fill:#000000;fill-opacity:0;stroke:#ffffff;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="M 24.996231,58.377 H 39.003769"
-     id="path945" />
-  <path
-     style="fill:#000000;fill-opacity:0;stroke:#ffffff;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="M 29.66541,58.377 32,61.500293 34.334589,58.377"
-     id="path947" />
-  <g
-     aria-label="1"
-     id="1"
-     style="font-weight:500;font-size:26px;font-family:OpenSans-SemiBold, 'Open Sans';fill:#000000;fill-rule:evenodd;stroke:none;stroke-width:0.922948"
-     transform="matrix(1.0834833,0,0,1.0834833,-10.213646,-12.319782)">
-    <path
-       d="M 41.172363,44.729492 H 38.366699 V 29.40625 l -2.539062,1.421875 v -2.932617 l 2.666015,-1.625 h 2.678711 z"
-       id="path862"
-       style="stroke-width:0.922948" />
-  </g>
+	<path id="path943" fill="none" stroke="#FFFFFF" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" d="
+	M20.327,56.986L10.21,55.034V44.104l2.724-3.904V19.897l-2.724-4.685v-9.37l4.28-2.342h6.615l2.334,3.124h17.121L42.895,3.5h6.615
+	l4.279,2.342v9.37l-2.723,4.685v20.302l2.723,3.904v10.931l-10.116,1.952l-3.112-3.514H23.44L20.327,56.986"/>
+	<path id="path945" fill-opacity="0" stroke="#FFFFFF" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" d="
+	M24.996,58.377h14.008"/>
+	<path id="path947" fill-opacity="0" stroke="#FFFFFF" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" d="
+	M29.666,58.377L32,61.5l2.334-3.123"/>
+	<g>
+		<path fill="#FFFFFF" d="M32,10.918c-8.381,0-15.175,6.817-15.175,15.226c0,8.409,6.794,15.226,15.175,15.226
+		s15.175-6.817,15.175-15.226C47.175,17.735,40.381,10.918,32,10.918z M34.396,36.145h-3.041V19.542l-2.751,1.541v-3.177
+		l2.889-1.761h2.903V36.145z"/>
+	</g>
+	<path fill="none" d="z"/>
 </svg>

--- a/styles/z-bolt/images/extruder-2.svg
+++ b/styles/z-bolt/images/extruder-2.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+	xmlns:dc="http://purl.org/dc/elements/1.1/"
+	xmlns:cc="http://creativecommons.org/ns#"
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:svg="http://www.w3.org/2000/svg"
+	xmlns="http://www.w3.org/2000/svg"
+	xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+	xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="64"
    height="64"
    viewBox="0 0 64 64"
@@ -14,21 +14,21 @@
    id="svg10"
    sodipodi:docname="extruder-2.svg"
    inkscape:version="1.0.2 (e86c870879, 2021-01-15, custom)">
-  <metadata
+	<metadata
      id="metadata16">
-    <rdf:RDF>
-      <cc:Work
+		<rdf:RDF>
+			<cc:Work
          rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
+				<dc:format>image/svg+xml</dc:format>
+				<dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title>folder</dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <defs
+				<dc:title>folder</dc:title>
+			</cc:Work>
+		</rdf:RDF>
+	</metadata>
+	<defs
      id="defs14" />
-  <sodipodi:namedview
+	<sodipodi:namedview
      pagecolor="#bfbfbf"
      bordercolor="#666666"
      borderopacity="1"
@@ -43,49 +43,43 @@
      showgrid="false"
      inkscape:pagecheckerboard="false"
      inkscape:zoom="5.4137931"
-     inkscape:cx="38.196925"
-     inkscape:cy="43.755812"
+     inkscape:cx="32.109123"
+     inkscape:cy="22.356606"
      inkscape:window-x="-8"
      inkscape:window-y="-8"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg10"
      inkscape:snap-bbox="true"
      inkscape:snap-bbox-edge-midpoints="true"
-     inkscape:document-rotation="0" />
-  <!-- Generator: Sketch 52.5 (67469) - http://www.bohemiancoding.com/sketch -->
-  <title
+     inkscape:document-rotation="0"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-midpoints="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:bbox-nodes="true"
+     inkscape:bbox-paths="true" />
+	<!-- Generator: Sketch 52.5 (67469) - http://www.bohemiancoding.com/sketch -->
+	<title
      id="title2">folder</title>
-  <desc
+	<desc
      id="desc4">Created with Sketch.</desc>
-  <ellipse
-     id="Oval"
-     stroke="#ffffff"
-     stroke-width="2"
-     cx="32"
-     cy="26.143875"
-     style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke-width:3;stroke-miterlimit:4;stroke-dasharray:none"
-     rx="15.174833"
-     ry="15.226054" />
-  <path
-     style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="M 20.327052,56.986395 10.210495,55.034337 V 44.102811 l 2.723688,-3.904116 V 19.897289 l -2.723688,-4.68494 V 5.8424699 L 14.490576,3.5 h 6.614672 l 2.33459,3.1232932 H 40.560162 L 42.894752,3.5 h 6.614672 l 4.280081,2.3424699 v 9.3698791 l -2.723688,4.68494 v 20.301406 l 2.723688,3.904116 V 55.034337 L 43.672948,56.986395 40.560162,53.472691 H 23.439838 l -3.112786,3.513704"
-     id="path943" />
-  <path
-     style="fill:#000000;fill-opacity:0;stroke:#ffffff;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="M 24.996231,58.377 H 39.003769"
-     id="path945" />
-  <path
-     style="fill:#000000;fill-opacity:0;stroke:#ffffff;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="M 29.66541,58.377 32,61.500293 34.334589,58.377"
-     id="path947" />
-  <g
-     aria-label="2"
-     id="2"
-     style="font-weight:500;font-size:26px;font-family:OpenSans-SemiBold, 'Open Sans';fill:#000000;fill-rule:evenodd;stroke:none;stroke-width:0.93247"
-     transform="matrix(1.0724195,0,0,1.0724195,-9.2881502,-11.92702)">
-    <path
-       d="m 33.345703,42.361816 6.411133,-8.518554 q 0.533203,-0.698242 0.825195,-1.434571 0.291992,-0.749023 0.291992,-1.396484 v -0.02539 q 0,-1.015625 -0.609375,-1.574218 -0.609375,-0.558594 -1.726562,-0.558594 -1.066406,0 -1.726563,0.647461 -0.647461,0.634765 -0.799804,1.81543 v 0.0127 h -2.894532 v -0.0127 q 0.203125,-1.625 0.901368,-2.780274 0.710937,-1.155273 1.853515,-1.751953 1.142578,-0.609375 2.640625,-0.609375 1.663086,0 2.84375,0.571289 1.19336,0.558594 1.802735,1.637695 0.62207,1.079102 0.62207,2.602539 v 0.0127 q 0,1.041015 -0.418945,2.158203 -0.40625,1.104492 -1.155274,2.094726 l -5.141601,6.893555 h 6.817382 v 2.678711 H 33.345703 Z"
-       id="path864"
-       style="stroke-width:0.93247" />
-  </g>
+	<path id="path943" fill="none" stroke="#FFFFFF" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" d="
+	M20.327,56.986L10.21,55.034V44.104l2.724-3.904V19.897l-2.724-4.685v-9.37l4.28-2.342h6.615l2.334,3.124h17.121L42.895,3.5h6.615
+	l4.279,2.342v9.37l-2.723,4.685v20.302l2.723,3.904v10.931l-10.116,1.952l-3.112-3.514H23.44L20.327,56.986"/>
+	<path id="path945" fill-opacity="0" stroke="#FFFFFF" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" d="
+	M24.996,58.377h14.008"/>
+	<path id="path947" fill-opacity="0" stroke="#FFFFFF" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" d="
+	M29.666,58.377L32,61.5l2.334-3.123"/>
+	<g>
+		<path fill="#FFFFFF" d="M32,10.918c-8.381,0-15.175,6.817-15.175,15.226c0,8.409,6.794,15.226,15.175,15.226
+		s15.175-6.817,15.175-15.226C47.175,17.735,40.381,10.918,32,10.918z M37.772,36.145h-11.3v-2.643l6.875-9.135
+		c0.381-0.499,0.676-1.012,0.885-1.539c0.209-0.535,0.313-1.035,0.313-1.498v-0.027c0-0.726-0.218-1.289-0.653-1.688
+		s-1.053-0.599-1.852-0.599c-0.763,0-1.38,0.231-1.852,0.694c-0.463,0.454-0.749,1.103-0.858,1.947v0.014h-3.104v-0.014
+		c0.145-1.162,0.467-2.155,0.966-2.981c0.508-0.826,1.171-1.452,1.988-1.879c0.817-0.436,1.761-0.653,2.832-0.653
+		c1.189,0,2.205,0.204,3.05,0.612c0.853,0.399,1.497,0.985,1.933,1.756c0.445,0.771,0.668,1.702,0.668,2.791v0.014
+		c0,0.745-0.15,1.516-0.449,2.314c-0.291,0.79-0.703,1.539-1.239,2.247l-5.514,7.393h7.311V36.145z"/>
+	</g>
+	<path fill="none" d="z"/>
 </svg>

--- a/styles/z-bolt/images/extruder-3.svg
+++ b/styles/z-bolt/images/extruder-3.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+	xmlns:dc="http://purl.org/dc/elements/1.1/"
+	xmlns:cc="http://creativecommons.org/ns#"
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:svg="http://www.w3.org/2000/svg"
+	xmlns="http://www.w3.org/2000/svg"
+	xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+	xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="64"
    height="64"
    viewBox="0 0 64 64"
@@ -14,21 +14,21 @@
    id="svg10"
    sodipodi:docname="extruder-3.svg"
    inkscape:version="1.0.2 (e86c870879, 2021-01-15, custom)">
-  <metadata
+	<metadata
      id="metadata16">
-    <rdf:RDF>
-      <cc:Work
+		<rdf:RDF>
+			<cc:Work
          rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
+				<dc:format>image/svg+xml</dc:format>
+				<dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title>folder</dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <defs
+				<dc:title>folder</dc:title>
+			</cc:Work>
+		</rdf:RDF>
+	</metadata>
+	<defs
      id="defs14" />
-  <sodipodi:namedview
+	<sodipodi:namedview
      pagecolor="#bfbfbf"
      bordercolor="#666666"
      borderopacity="1"
@@ -43,49 +43,48 @@
      showgrid="false"
      inkscape:pagecheckerboard="false"
      inkscape:zoom="5.4137931"
-     inkscape:cx="38.196925"
-     inkscape:cy="43.755812"
+     inkscape:cx="32.109123"
+     inkscape:cy="22.356606"
      inkscape:window-x="-8"
      inkscape:window-y="-8"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg10"
      inkscape:snap-bbox="true"
      inkscape:snap-bbox-edge-midpoints="true"
-     inkscape:document-rotation="0" />
-  <!-- Generator: Sketch 52.5 (67469) - http://www.bohemiancoding.com/sketch -->
-  <title
+     inkscape:document-rotation="0"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-midpoints="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:bbox-nodes="true"
+     inkscape:bbox-paths="true" />
+	<!-- Generator: Sketch 52.5 (67469) - http://www.bohemiancoding.com/sketch -->
+	<title
      id="title2">folder</title>
-  <desc
+	<desc
      id="desc4">Created with Sketch.</desc>
-  <ellipse
-     id="Oval"
-     stroke="#ffffff"
-     stroke-width="2"
-     cx="32"
-     cy="26.143875"
-     style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke-width:3;stroke-miterlimit:4;stroke-dasharray:none"
-     rx="15.174833"
-     ry="15.226054" />
-  <path
-     style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="M 20.327052,56.986395 10.210495,55.034337 V 44.102811 l 2.723688,-3.904116 V 19.897289 l -2.723688,-4.68494 V 5.8424699 L 14.490576,3.5 h 6.614672 l 2.33459,3.1232932 H 40.560162 L 42.894752,3.5 h 6.614672 l 4.280081,2.3424699 v 9.3698791 l -2.723688,4.68494 v 20.301406 l 2.723688,3.904116 V 55.034337 L 43.672948,56.986395 40.560162,53.472691 H 23.439838 l -3.112786,3.513704"
-     id="path943" />
-  <path
-     style="fill:#000000;fill-opacity:0;stroke:#ffffff;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="M 24.996231,58.377 H 39.003769"
-     id="path945" />
-  <path
-     style="fill:#000000;fill-opacity:0;stroke:#ffffff;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="M 29.66541,58.377 32,61.500293 34.334589,58.377"
-     id="path947" />
-  <g
-     aria-label="3"
-     id="3"
-     style="font-weight:500;font-size:26px;font-family:OpenSans-SemiBold, 'Open Sans';fill:#000000;fill-rule:evenodd;stroke:none;stroke-width:0.941991"
-     transform="matrix(1.0615799,0,0,1.0615799,-8.8708261,-11.542211)">
-    <path
-       d="m 38.645996,44.919922 q -1.574219,0 -2.792969,-0.571289 -1.206054,-0.583985 -1.942382,-1.675781 -0.723633,-1.091797 -0.888672,-2.62793 v 0 h 2.881836 v 0 q 0.101562,0.723633 0.444336,1.206055 0.355468,0.482421 0.901367,0.723632 0.558593,0.241211 1.307617,0.241211 1.206055,0 1.878906,-0.647461 0.672852,-0.660156 0.672852,-1.84082 v -0.533203 q 0,-1.307617 -0.622071,-2.005859 -0.609375,-0.710938 -1.739257,-0.710938 h -1.371094 v -2.691406 h 1.371094 q 0.977539,0 1.510742,-0.609375 0.545898,-0.609375 0.545898,-1.726563 v -0.507812 q 0,-1.028321 -0.571289,-1.586914 -0.571289,-0.571289 -1.625,-0.571289 -0.609375,0 -1.104492,0.253906 -0.482422,0.241211 -0.825195,0.749023 -0.330078,0.495118 -0.482422,1.231446 v 0 H 33.32666 v 0 q 0.228516,-1.548828 0.939453,-2.666016 0.723633,-1.117187 1.828125,-1.688477 1.117188,-0.583984 2.539063,-0.583984 2.412109,0 3.719726,1.256836 1.320313,1.256836 1.320313,3.541992 v 0.368164 q 0,1.358399 -0.723633,2.374024 -0.723633,1.002929 -2.056641,1.472656 1.472657,0.330078 2.272461,1.472656 0.8125,1.129883 0.8125,2.894531 v 0.368165 q 0,1.612304 -0.634765,2.754882 -0.622071,1.142578 -1.81543,1.739258 -1.193359,0.59668 -2.881836,0.59668 z"
-       id="path862"
-       style="stroke-width:0.941991" />
-  </g>
+	<path id="path943" fill="none" stroke="#FFFFFF" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" d="
+	M20.327,56.986L10.21,55.034V44.104l2.724-3.904V19.897l-2.724-4.685v-9.37l4.28-2.342h6.615l2.334,3.124h17.121L42.895,3.5h6.615
+	l4.279,2.342v9.37l-2.723,4.685v20.302l2.723,3.904v10.931l-10.116,1.952l-3.112-3.514H23.44L20.327,56.986"/>
+	<path id="path945" fill-opacity="0" stroke="#FFFFFF" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" d="
+	M24.996,58.377h14.008"/>
+	<path id="path947" fill-opacity="0" stroke="#FFFFFF" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" d="
+	M29.666,58.377L32,61.5l2.334-3.123"/>
+	<g>
+		<path fill="#FFFFFF" d="M32,10.918c-8.381,0-15.175,6.817-15.175,15.226c0,8.409,6.794,15.226,15.175,15.226
+		s15.175-6.817,15.175-15.226C47.175,17.735,40.381,10.918,32,10.918z M37.815,30.74c0,1.141-0.225,2.116-0.674,2.924
+		c-0.44,0.809-1.083,1.424-1.927,1.846c-0.846,0.423-1.865,0.635-3.06,0.635c-1.114,0-2.102-0.203-2.965-0.607
+		c-0.854-0.413-1.541-1.006-2.062-1.779c-0.512-0.771-0.827-1.702-0.943-2.789h3.06c0.072,0.512,0.229,0.939,0.472,1.28
+		c0.251,0.341,0.57,0.597,0.957,0.769c0.396,0.17,0.858,0.256,1.388,0.256c0.854,0,1.519-0.229,1.994-0.688
+		c0.477-0.467,0.715-1.119,0.715-1.954v-0.566c0-0.926-0.221-1.635-0.66-2.13c-0.432-0.503-1.047-0.754-1.847-0.754h-1.456v-2.857
+		h1.456c0.692,0,1.227-0.216,1.604-0.647c0.386-0.432,0.579-1.042,0.579-1.833v-0.539c0-0.728-0.202-1.29-0.606-1.685
+		c-0.404-0.404-0.979-0.606-1.725-0.606c-0.432,0-0.822,0.09-1.173,0.27c-0.341,0.17-0.633,0.436-0.876,0.795
+		c-0.233,0.351-0.404,0.786-0.512,1.307h-3.045c0.162-1.096,0.494-2.039,0.997-2.83c0.512-0.791,1.159-1.388,1.941-1.792
+		c0.791-0.413,1.689-0.62,2.695-0.62c1.707,0,3.023,0.444,3.948,1.334c0.936,0.89,1.402,2.143,1.402,3.76v0.391
+		c0,0.961-0.256,1.802-0.769,2.521c-0.513,0.709-1.239,1.231-2.183,1.563c1.041,0.234,1.846,0.755,2.412,1.563
+		c0.574,0.8,0.862,1.824,0.862,3.073V30.74z"/>
+	</g>
+	<path fill="none" d="z"/>
 </svg>

--- a/styles/z-bolt/images/extruder-4.svg
+++ b/styles/z-bolt/images/extruder-4.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+	xmlns:dc="http://purl.org/dc/elements/1.1/"
+	xmlns:cc="http://creativecommons.org/ns#"
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:svg="http://www.w3.org/2000/svg"
+	xmlns="http://www.w3.org/2000/svg"
+	xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+	xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="64"
    height="64"
    viewBox="0 0 64 64"
@@ -14,21 +14,21 @@
    id="svg10"
    sodipodi:docname="extruder-4.svg"
    inkscape:version="1.0.2 (e86c870879, 2021-01-15, custom)">
-  <metadata
+	<metadata
      id="metadata16">
-    <rdf:RDF>
-      <cc:Work
+		<rdf:RDF>
+			<cc:Work
          rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
+				<dc:format>image/svg+xml</dc:format>
+				<dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title>folder</dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <defs
+				<dc:title>folder</dc:title>
+			</cc:Work>
+		</rdf:RDF>
+	</metadata>
+	<defs
      id="defs14" />
-  <sodipodi:namedview
+	<sodipodi:namedview
      pagecolor="#bfbfbf"
      bordercolor="#666666"
      borderopacity="1"
@@ -43,43 +43,39 @@
      showgrid="false"
      inkscape:pagecheckerboard="false"
      inkscape:zoom="5.4137931"
-     inkscape:cx="38.196925"
-     inkscape:cy="43.755812"
+     inkscape:cx="32.109123"
+     inkscape:cy="22.356606"
      inkscape:window-x="-8"
      inkscape:window-y="-8"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg10"
      inkscape:snap-bbox="true"
      inkscape:snap-bbox-edge-midpoints="true"
-     inkscape:document-rotation="0" />
-  <!-- Generator: Sketch 52.5 (67469) - http://www.bohemiancoding.com/sketch -->
-  <title
+     inkscape:document-rotation="0"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-midpoints="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:bbox-nodes="true"
+     inkscape:bbox-paths="true" />
+	<!-- Generator: Sketch 52.5 (67469) - http://www.bohemiancoding.com/sketch -->
+	<title
      id="title2">folder</title>
-  <desc
+	<desc
      id="desc4">Created with Sketch.</desc>
-  <ellipse
-     id="Oval"
-     stroke="#ffffff"
-     stroke-width="2"
-     cx="32"
-     cy="26.143875"
-     style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke-width:3;stroke-miterlimit:4;stroke-dasharray:none"
-     rx="15.174833"
-     ry="15.226054" />
-  <path
-     style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="M 20.327052,56.986395 10.210495,55.034337 V 44.102811 l 2.723688,-3.904116 V 19.897289 l -2.723688,-4.68494 V 5.8424699 L 14.490576,3.5 h 6.614672 l 2.33459,3.1232932 H 40.560162 L 42.894752,3.5 h 6.614672 l 4.280081,2.3424699 v 9.3698791 l -2.723688,4.68494 v 20.301406 l 2.723688,3.904116 V 55.034337 L 43.672948,56.986395 40.560162,53.472691 H 23.439838 l -3.112786,3.513704"
-     id="path943" />
-  <path
-     style="fill:#000000;fill-opacity:0;stroke:#ffffff;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="M 24.996231,58.377 H 39.003769"
-     id="path945" />
-  <path
-     style="fill:#000000;fill-opacity:0;stroke:#ffffff;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="M 29.66541,58.377 32,61.500293 34.334589,58.377"
-     id="path947" />
-  <path
-     d="m 25.500687,30.366709 6.574967,-14.222834 h 3.232462 l -6.409904,14.057772 h 9.601101 V 33.06272 H 25.500687 Z m 8.486935,-5.99725 h 2.998624 v 11.774416 h -2.998624 z"
-     id="path862"
-     style="font-weight:500;font-size:26px;font-family:OpenSans-SemiBold, 'Open Sans';fill:#000000;fill-rule:evenodd;stroke:none;stroke-width:0.999998" />
+	<path id="path943" fill="none" stroke="#FFFFFF" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" d="
+	M20.327,56.986L10.21,55.034V44.104l2.724-3.904V19.897l-2.724-4.685v-9.37l4.28-2.342h6.615l2.334,3.124h17.121L42.895,3.5h6.615
+	l4.279,2.342v9.37l-2.723,4.685v20.302l2.723,3.904v10.931l-10.116,1.952l-3.112-3.514H23.44L20.327,56.986"/>
+	<path id="path945" fill-opacity="0" stroke="#FFFFFF" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" d="
+	M24.996,58.377h14.008"/>
+	<path id="path947" fill-opacity="0" stroke="#FFFFFF" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" d="
+	M29.666,58.377L32,61.5l2.334-3.123"/>
+	<g>
+		<path fill="#FFFFFF" d="M32,10.918c-8.381,0-15.175,6.817-15.175,15.226c0,8.409,6.794,15.226,15.175,15.226
+		s15.175-6.817,15.175-15.226C47.175,17.735,40.381,10.918,32,10.918z M38.5,33.063h-1.514v3.082h-2.998v-3.082H25.5v-2.696
+		l6.575-14.223h3.233l-6.41,14.058h5.09V24.37h2.998v5.832H38.5V33.063z"/>
+	</g>
+	<path fill="none" d="z"/>
 </svg>

--- a/styles/z-bolt/images/filament.svg
+++ b/styles/z-bolt/images/filament.svg
@@ -1,34 +1,35 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="64"
-   height="64"
-   viewBox="0 0 64 64"
-   version="1.1"
-   id="svg10"
-   sodipodi:docname="filament.svg"
-   inkscape:version="1.0.2 (e86c870879, 2021-01-15, custom)">
-  <metadata
+	xmlns:dc="http://purl.org/dc/elements/1.1/"
+	xmlns:cc="http://creativecommons.org/ns#"
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:svg="http://www.w3.org/2000/svg"
+	xmlns="http://www.w3.org/2000/svg"
+	xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+	xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+	xmlns:xlink="http://www.w3.org/1999/xlink"	 
+	 width="64"
+	 height="64"
+	 viewBox="0 0 64 64"
+	 version="1.1"   
+	 id="svg10"	 
+	 sodipodi:docname="filament.svg"
+	 inkscape:version="1.0.2 (e86c870879, 2021-01-15, custom)">
+	<metadata
      id="metadata16">
-    <rdf:RDF>
-      <cc:Work
+		<rdf:RDF>
+			<cc:Work
          rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
+				<dc:format>image/svg+xml</dc:format>
+				<dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title>folder</dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <defs
+				<dc:title>folder</dc:title>
+			</cc:Work>
+		</rdf:RDF>
+	</metadata>
+	<defs
      id="defs14" />
-  <sodipodi:namedview
+	<sodipodi:namedview
      pagecolor="#bfbfbf"
      bordercolor="#666666"
      borderopacity="1"
@@ -42,86 +43,62 @@
      id="namedview12"
      showgrid="false"
      inkscape:pagecheckerboard="false"
-     inkscape:zoom="7.6562596"
-     inkscape:cx="20.959822"
-     inkscape:cy="36.260589"
+     inkscape:zoom="5.4137931"
+     inkscape:cx="32.109123"
+     inkscape:cy="22.356606"
      inkscape:window-x="-8"
      inkscape:window-y="-8"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg10"
      inkscape:snap-bbox="true"
      inkscape:snap-bbox-edge-midpoints="true"
-     inkscape:document-rotation="0" />
-  <!-- Generator: Sketch 52.5 (67469) - http://www.bohemiancoding.com/sketch -->
-  <title
+     inkscape:document-rotation="0"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-midpoints="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:bbox-nodes="true"
+     inkscape:bbox-paths="true" />
+	<!-- Generator: Sketch 52.5 (67469) - http://www.bohemiancoding.com/sketch -->
+	<title
      id="title2">folder</title>
-  <path
-     transform="matrix(-0.39323461,-0.91943816,-0.91943816,0.39323461,58.036686,-8.577075)"
-     sodipodi:t0="0.099065192"
-     sodipodi:argument="-18.248306"
-     sodipodi:radius="15.811388"
-     sodipodi:revolution="3.1031001"
-     sodipodi:expansion="1"
-     sodipodi:cy="39"
-     sodipodi:cx="-30"
-     id="path840"
-     style="fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     sodipodi:type="spiral"
-     d="m -31.284908,39.895818 c -1.198803,-0.630572 -1.09331,-2.300702 -0.339433,-3.225675 1.267095,-1.554666 3.647254,-1.326933 4.999147,-0.02301 1.930179,1.861695 1.56899,5.008763 -0.29342,6.772618 -2.443845,2.31452 -6.376152,1.815029 -8.54609,-0.609847 -2.703239,-3.020834 -2.06322,-7.746507 0.926274,-10.319561 3.595222,-3.094403 9.118585,-2.312689 12.093032,1.2427 3.487061,4.168123 2.562974,10.491758 -1.559127,13.866504 -4.740096,3.880696 -11.865671,2.813808 -15.639975,-1.875553 -4.275004,-5.311453 -3.065031,-13.240108 2.19198,-17.413447 5.882377,-4.669793 14.61493,-3.316538 19.186918,2.508406 5.06494,6.45299 3.568258,15.990044 -2.824833,20.96039 -1.187576,0.923288 -2.50884,1.672532 -3.909575,2.220656" />
-  <desc
+	<desc
      id="desc4">Created with Sketch.</desc>
-  <path
-     sodipodi:nodetypes="ccc"
-     inkscape:connector-curvature="0"
-     id="path4710-2"
-     d="m 14.791877,50.362604 3.756999,5.270354 3.638377,-5.270354 z"
-     style="display:inline;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     transform="matrix(-0.39323461,-0.91943816,-0.91943816,0.39323461,68.094083,-17.741658)"
-     sodipodi:t0="0"
-     sodipodi:argument="-18.248306"
-     sodipodi:radius="15.811388"
-     sodipodi:revolution="3.1031001"
-     sodipodi:expansion="1"
-     sodipodi:cy="39"
-     sodipodi:cx="-30"
-     id="path4178-3"
-     style="display:inline;fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:3.00000002;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     sodipodi:type="spiral"
-     d="m -30,39 c 0.632011,0.433543 -0.272595,1.065833 -0.720576,1.050444 -1.214003,-0.0417 -1.679539,-1.500029 -1.380313,-2.491597 0.535246,-1.773681 2.672376,-2.367848 4.262618,-1.71018 2.333744,0.965154 3.072795,3.859266 2.040048,6.033638 -1.376489,2.898097 -5.051141,3.784606 -7.804659,2.369916 -3.465021,-1.780242 -4.499921,-6.245348 -2.699784,-9.575679 2.180207,-4.033478 7.44086,-5.217257 11.3467,-3.029652 4.602897,2.578016 5.93586,8.637184 3.35952,13.117721 -2.974486,5.172956 -9.83405,6.655308 -14.888741,3.689388 -5.743461,-3.370068 -7.375348,-11.031299 -4.019256,-16.659762 3.765029,-6.314286 12.228824,-8.095819 18.430783,-4.349124 6.885349,4.159541 8.816611,13.42656 4.678991,20.201803 -1.758712,2.879846 -4.465402,5.124393 -7.605341,6.353087" />
-  <circle
-     r="17.5"
-     cy="33.269299"
-     cx="33.884361"
-     id="path4173"
-     style="display:inline;fill:#232323;fill-opacity:1;stroke:none;stroke-opacity:1;stroke-width:3;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     transform="matrix(-0.39323461,-0.91943816,-0.91943816,0.39323461,58.036686,-8.577075)"
-     sodipodi:t0="0.059999999"
-     sodipodi:argument="-18.248306"
-     sodipodi:radius="15.811388"
-     sodipodi:revolution="3.1031001"
-     sodipodi:expansion="1"
-     sodipodi:cy="39"
-     sodipodi:cx="-30"
-     id="path4178"
-     style="fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     sodipodi:type="spiral"
-     d="m -30.188748,39.929717 c -0.934735,0.519164 -1.86112,-0.521065 -1.989341,-1.371905 -0.251012,-1.665654 1.328258,-2.941581 2.873717,-2.984272 2.351445,-0.06496 4.050387,2.14491 3.979204,4.375529 -0.09676,3.031973 -2.964117,5.169371 -5.877341,4.974134 -3.711588,-0.248741 -6.293217,-3.784274 -5.969066,-7.379152 0.395943,-4.391064 4.604908,-7.419768 8.880964,-6.963998 5.070571,0.540456 8.54798,5.425827 7.958929,10.382776 -0.683308,5.750143 -6.246931,9.677284 -11.884587,8.953861 -6.429779,-0.825068 -10.807344,-7.068166 -9.948792,-13.386399 0.966069,-7.109471 7.889496,-11.93795 14.888211,-10.943724 7.789209,1.106523 13.068961,8.710898 11.938654,16.390023 -0.796629,5.412169 -4.585032,10.036809 -9.661814,12.023413" />
-  <path
-     inkscape:connector-curvature="0"
-     id="path4180"
-     d="m 18.231635,35.314384 v 15"
-     style="fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     inkscape:connector-curvature="0"
-     id="path4190"
-     d="M 26.095284,8.525404 C 8.8082808,23.285118 8.8082808,23.285118 8.8082808,23.285118"
-     style="fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     sodipodi:nodetypes="ccc"
-     inkscape:connector-curvature="0"
-     id="path4710-2-1"
-     d="M 28.151046,13.157801 29.744732,4.494965 21.122889,5.75034 Z"
-     style="display:inline;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+	<path id="path840" sodipodi:t0="0.099065192" sodipodi:radius="15.811388" sodipodi:cy="39" sodipodi:cx="-30" sodipodi:type="spiral" sodipodi:expansion="1" sodipodi:revolution="3.1031001" sodipodi:argument="-18.248306" fill="none" stroke="#FFFFFF" stroke-width="3" stroke-linejoin="round" d="
+	M33.657,35.876c1.052,0.854,2.546,0.101,3.099-0.956c0.932-1.777-0.213-3.875-1.943-4.606c-2.471-1.042-5.223,0.527-6.112,2.933
+	c-1.167,3.157,0.838,6.576,3.921,7.618c3.841,1.297,7.934-1.149,9.125-4.91c1.431-4.522-1.46-9.293-5.898-10.63
+	c-5.204-1.567-10.654,1.769-12.136,6.886c-1.704,5.884,2.079,12.016,7.875,13.642c6.564,1.842,13.379-2.389,15.148-8.863
+	c1.98-7.244-2.697-14.741-9.852-16.654c-7.924-2.119-16.104,3.007-18.161,10.84c-0.382,1.455-0.551,2.965-0.504,4.468"/>
+	<desc  id="desc4">Created with Sketch.</desc>
+	<path id="path4710-2" sodipodi:nodetypes="ccc" inkscape:connector-curvature="0" fill="#FFFFFF" stroke="#FFFFFF" stroke-width="3" stroke-linejoin="round" d="
+	M14.792,50.363l3.757,5.27l3.639-5.27H14.792z"/>
+	<g>
+		<defs>
+			<path id="SVGID_1_" d="M62.139,25.178c0-10-8.105-18.106-18.105-18.106c-6.979,0-13.025,3.954-16.047,9.738
+			c1.846-0.662,3.826-1.041,5.899-1.041c9.664,0,17.5,7.835,17.5,17.5c0,3.465-1.021,6.686-2.758,9.403
+			C56.398,40.637,62.139,33.587,62.139,25.178z"/>
+		</defs>
+		<clipPath id="SVGID_2_">
+			<use xlink:href="#SVGID_1_"  overflow="visible"/>
+		</clipPath>
+		<path id="path4178-3" sodipodi:t0="0" sodipodi:radius="15.811388" sodipodi:cy="39" sodipodi:cx="-30" sodipodi:type="spiral" sodipodi:expansion="1" sodipodi:revolution="3.1031001" sodipodi:argument="-18.248306" clip-path="url(#SVGID_2_)" fill="none" stroke="#FFFFFF" stroke-width="3" stroke-linejoin="round" d="
+		M44.033,25.178c-0.647-0.411-0.873,0.669-0.683,1.076c0.516,1.1,2.04,0.954,2.833,0.289c1.421-1.189,1.127-3.388-0.104-4.592
+		c-1.805-1.766-4.756-1.308-6.35,0.497c-2.123,2.405-1.493,6.132,0.891,8.108c2.999,2.485,7.512,1.681,9.865-1.283
+		c2.852-3.591,1.871-8.893-1.676-11.624c-4.181-3.218-10.275-2.061-13.383,2.069c-3.586,4.769-2.252,11.659,2.463,15.14
+		c5.357,3.956,13.043,2.443,16.898-2.855c4.325-5.945,2.635-14.427-3.249-18.656c-6.532-4.695-15.812-2.827-20.414,3.642
+		c-1.957,2.75-2.956,6.121-2.851,9.491"/>
+	</g>
+	<path id="path4178" sodipodi:t0="0.059999999" sodipodi:radius="15.811388" sodipodi:cy="39" sodipodi:cx="-30" sodipodi:type="spiral" sodipodi:expansion="1" sodipodi:revolution="3.1031001" sodipodi:argument="-18.248306" fill="none" stroke="#FFFFFF" stroke-width="3" stroke-linejoin="round" d="
+	M33.195,34.881c-0.109,1.064,1.211,1.507,2.043,1.29c1.631-0.425,2.183-2.378,1.614-3.816c-0.865-2.188-3.565-2.88-5.588-1.938
+	c-2.75,1.281-3.587,4.759-2.262,7.36c1.688,3.314,5.955,4.298,9.132,2.586c3.881-2.09,5.011-7.151,2.91-10.904
+	c-2.49-4.45-8.35-5.726-12.676-3.235c-5.019,2.89-6.441,9.549-3.559,14.448c3.287,5.587,10.749,7.157,16.22,3.884
+	c6.157-3.685,7.874-11.949,4.208-17.993c-4.081-6.727-13.149-8.591-19.765-4.532c-4.663,2.86-7.425,8.163-7.255,13.611"/>
+	<path id="path4180" inkscape:connector-curvature="0" fill="none" stroke="#FFFFFF" stroke-width="3" stroke-linejoin="round" d="
+	M18.231,35.314v15"/>
+	<path id="path4190" inkscape:connector-curvature="0" fill="none" stroke="#FFFFFF" stroke-width="4" stroke-linecap="round" d="
+	M26.095,8.525C8.808,23.285,8.808,23.285,8.808,23.285"/>
+	<path id="path4710-2-1" sodipodi:nodetypes="ccc" inkscape:connector-curvature="0" fill="#FFFFFF" stroke="#FFFFFF" stroke-width="3" stroke-linejoin="round" d="
+	M28.151,13.158l1.594-8.663L21.123,5.75L28.151,13.158z"/>
 </svg>

--- a/styles/z-bolt/images/motor-off.svg
+++ b/styles/z-bolt/images/motor-off.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+	xmlns:dc="http://purl.org/dc/elements/1.1/"
+	xmlns:cc="http://creativecommons.org/ns#"
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:svg="http://www.w3.org/2000/svg"
+	xmlns="http://www.w3.org/2000/svg"
+	xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+	xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="64"
    height="64"
    viewBox="0 0 64 64"
@@ -14,21 +14,21 @@
    id="svg10"
    sodipodi:docname="motor-off.svg"
    inkscape:version="1.0.2 (e86c870879, 2021-01-15, custom)">
-  <metadata
+	<metadata
      id="metadata16">
-    <rdf:RDF>
-      <cc:Work
+		<rdf:RDF>
+			<cc:Work
          rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
+				<dc:format>image/svg+xml</dc:format>
+				<dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title>folder</dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <defs
+				<dc:title>folder</dc:title>
+			</cc:Work>
+		</rdf:RDF>
+	</metadata>
+	<defs
      id="defs14" />
-  <sodipodi:namedview
+	<sodipodi:namedview
      pagecolor="#bfbfbf"
      bordercolor="#666666"
      borderopacity="1"
@@ -43,61 +43,70 @@
      showgrid="false"
      inkscape:pagecheckerboard="false"
      inkscape:zoom="5.4137931"
-     inkscape:cx="22.518245"
-     inkscape:cy="36.93885"
+     inkscape:cx="32.109123"
+     inkscape:cy="22.356606"
      inkscape:window-x="-8"
      inkscape:window-y="-8"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg10"
      inkscape:snap-bbox="true"
      inkscape:snap-bbox-edge-midpoints="true"
-     inkscape:document-rotation="0" />
-  <!-- Generator: Sketch 52.5 (67469) - http://www.bohemiancoding.com/sketch -->
-  <title
+     inkscape:document-rotation="0"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-midpoints="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:bbox-nodes="true"
+     inkscape:bbox-paths="true" />
+	<!-- Generator: Sketch 52.5 (67469) - http://www.bohemiancoding.com/sketch -->
+	<title
      id="title2">folder</title>
-  <desc
+	<desc
      id="desc4">Created with Sketch.</desc>
-  <ellipse
-     ry="19.242332"
-     rx="19.008972"
-     cy="35.095352"
-     cx="32.056526"
-     id="path4508"
-     style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     sodipodi:nodetypes="cccccc"
-     inkscape:connector-curvature="0"
-     id="path4535"
-     d="M 31.658915,27.030904 47.819822,51.243879 40.611521,56.136648 24.450614,31.923673 24.204571,24.197024 Z"
-     style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-  <ellipse
-     ry="5.7694836"
-     rx="5.6916976"
-     cy="53.485729"
-     cx="44.023197"
-     id="path4149"
-     style="fill:#ffffff;fill-opacity:1;stroke-width:3;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     inkscape:connector-curvature="0"
-     id="path4153"
-     d="m 26.22356,26.943446 18.484378,27.54742"
-     style="fill:none;fill-rule:evenodd;stroke:#232323;stroke-width:3;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-  <g
-     aria-label="0"
-     id="text4803-5-0"
-     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.4544px;line-height:0%;font-family:Calibri;-inkscape-font-specification:'Calibri, Bold';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none">
-    <path
-       d="m 17.0499,9.6952621 q 0,1.1538719 -0.186108,2.0844139 -0.186109,0.930542 -0.610436,1.585644 -0.416883,0.655101 -1.094317,1.004985 -0.669991,0.349884 -1.645199,0.349884 -0.990096,0 -1.637754,-0.334995 -0.647657,-0.34244 -1.027318,-0.975208 -0.379661,-0.640213 -0.535992,-1.555866 -0.148887,-0.923098 -0.148887,-2.0844145 0,-1.1464278 0.186109,-2.0769698 0.193552,-0.9379863 0.610435,-1.5930879 0.424327,-0.6551016 1.094318,-1.0049854 0.677434,-0.3498837 1.645198,-0.3498837 0.990097,0 1.637754,0.3424394 0.655101,0.3349951 1.034762,0.975208 0.379662,0.6327686 0.528548,1.5558663 0.148887,0.9156533 0.148887,2.0769697 z m -1.972749,0.096776 q 0,-0.6848789 -0.03722,-1.2059824 Q 15.002708,8.0575082 14.92082,7.6704027 14.846377,7.2832973 14.727267,7.0153012 14.615602,6.7473051 14.451827,6.590974 14.288051,6.4271986 14.07961,6.3601996 q -0.208441,-0.066999 -0.461549,-0.066999 -0.439216,0 -0.729545,0.2158857 -0.282885,0.2084414 -0.454104,0.6327686 -0.163776,0.4243271 -0.230775,1.0570957 -0.067,0.6327686 -0.067,1.4739785 0,1.0273189 0.08189,1.7047529 0.08189,0.66999 0.253107,1.071984 0.178664,0.39455 0.454105,0.558326 0.27544,0.156331 0.662546,0.156331 0.290329,0 0.513659,-0.08933 0.22333,-0.09678 0.387105,-0.282885 0.17122,-0.186108 0.282885,-0.468993 0.111665,-0.282885 0.178664,-0.655102 0.07444,-0.372217 0.09678,-0.84121 0.02978,-0.468993 0.02978,-1.0347625 z"
-       style="font-size:15.246px;line-height:1.25;stroke-width:3;stroke-miterlimit:4;stroke-dasharray:none"
-       id="path940" />
-  </g>
-  <g
-     aria-label="1"
-     id="text4803-5-0-0"
-     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.4544px;line-height:0%;font-family:Calibri;-inkscape-font-specification:'Calibri, Bold';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none">
-    <path
-       d="m 53.836119,14.068771 q 0,0.208442 -0.02233,0.357328 -0.02233,0.141443 -0.067,0.230775 -0.03722,0.08189 -0.08933,0.119109 -0.05211,0.03722 -0.119109,0.03722 H 48.22309 q -0.05955,0 -0.111665,-0.03722 -0.05211,-0.03722 -0.09678,-0.119109 -0.03722,-0.08933 -0.05955,-0.230775 -0.02233,-0.148886 -0.02233,-0.357328 0,-0.215886 0.01489,-0.357328 0.02233,-0.148887 0.05955,-0.238219 0.04467,-0.08933 0.09678,-0.126553 0.05211,-0.04467 0.119109,-0.04467 h 1.794085 V 7.0338736 l -1.548422,0.8560986 q -0.17122,0.081888 -0.282885,0.1042207 -0.10422,0.014889 -0.171219,-0.044666 -0.05955,-0.066999 -0.08189,-0.2233301 -0.02233,-0.156331 -0.02233,-0.4392158 0,-0.1786641 0.0074,-0.2903291 0.0074,-0.1191094 0.03722,-0.2009971 0.02978,-0.081888 0.08189,-0.133998 0.05211,-0.05211 0.141442,-0.1116651 l 2.069525,-1.3399805 q 0.03722,-0.029777 0.08933,-0.044666 0.05955,-0.022333 0.148886,-0.029777 0.08933,-0.014889 0.230775,-0.014889 0.148886,-0.00744 0.379661,-0.00744 0.282885,0 0.454104,0.014889 0.178664,0.00744 0.267996,0.037222 0.08933,0.022333 0.11911,0.066999 0.02978,0.044666 0.02978,0.1116651 v 7.9579957 h 1.570755 q 0.067,0 0.119109,0.04467 0.05956,0.03722 0.09678,0.126553 0.04467,0.08933 0.05955,0.238219 0.02233,0.141442 0.02233,0.357328 z"
-       style="font-size:15.246px;line-height:1.25;stroke-width:3;stroke-miterlimit:4;stroke-dasharray:none"
-       id="path943" />
-  </g>
+	<path fill="#FFFFFF" d="M52.565,35.096c0-11.438-9.2-20.743-20.509-20.743c-11.309,0-20.509,9.305-20.509,20.743
+	s9.2,20.742,20.509,20.742c3.651,0,7.076-0.981,10.05-2.681l-1.678-2.484c-2.488,1.379-5.341,2.165-8.372,2.165
+	c-9.655,0-17.509-7.959-17.509-17.742s7.854-17.743,17.509-17.743c9.654,0,17.509,7.959,17.509,17.743
+	c0,5.656-2.636,10.691-6.717,13.942l1.679,2.486C49.404,47.729,52.565,41.786,52.565,35.096z"/>
+	<path fill="#FFFFFF" d="M49.068,50.411L32.906,26.198c-0.173-0.26-0.423-0.458-0.714-0.569l-7.454-2.834
+	c-0.469-0.179-0.997-0.111-1.404,0.181c-0.408,0.292-0.644,0.768-0.628,1.269l0.246,7.727c0.009,0.28,0.096,0.552,0.251,0.785
+	l16.16,24.213c0.223,0.332,0.568,0.563,0.96,0.639c0.096,0.02,0.192,0.028,0.288,0.028c0.298,0,0.592-0.089,0.843-0.259l2.525-1.714
+	c-0.141-0.089-0.271-0.193-0.375-0.323l-0.017,0.011l-4.025-5.962L25.738,28.915l0.025-0.017c-0.156-0.231-0.247-0.509-0.247-0.809
+	c0-0.804,0.652-1.454,1.456-1.454c0.577,0,1.07,0.337,1.306,0.823l13.693,20.28l3.859,5.716c0.18,0.199,0.282,0.455,0.332,0.729
+	l2.501-1.697C49.345,52.022,49.525,51.097,49.068,50.411z"/>
+	<path fill="#FFFFFF" d="M43.947,47.385c-0.694,0-1.358,0.129-1.977,0.354l3.859,5.716c0.233,0.26,0.379,0.599,0.379,0.975
+	c0,0.809-0.656,1.464-1.466,1.464c-0.463,0-0.87-0.218-1.139-0.552l-0.017,0.011l-4.025-5.962c-0.918,1.05-1.48,2.427-1.48,3.94
+	c0,3.283,2.626,5.945,5.865,5.945c3.238,0,5.865-2.662,5.865-5.945C49.813,50.045,47.186,47.385,43.947,47.385z"/>
+	<path id="path4153" inkscape:connector-curvature="0" display="none" fill="none" stroke="#232323" stroke-width="3" stroke-linecap="round" d="
+	M26.224,26.943L44.708,54.49"/>
+	<g id="text4803-5-0">
+		<path id="path940" fill="#FFFFFF" d="M17.05,9.695c0,0.769-0.062,1.464-0.186,2.084c-0.124,0.62-0.328,1.149-0.61,1.585
+		c-0.278,0.437-0.643,0.772-1.094,1.005c-0.447,0.233-0.995,0.35-1.646,0.35c-0.66,0-1.206-0.112-1.638-0.335
+		c-0.432-0.229-0.774-0.553-1.027-0.975c-0.253-0.427-0.432-0.946-0.536-1.556c-0.1-0.615-0.149-1.31-0.149-2.084
+		c0-0.764,0.062-1.457,0.186-2.077c0.129-0.625,0.333-1.156,0.61-1.593c0.283-0.437,0.647-0.771,1.094-1.005
+		c0.452-0.233,1-0.35,1.646-0.35c0.66,0,1.206,0.114,1.638,0.343c0.437,0.223,0.781,0.548,1.035,0.975
+		c0.253,0.422,0.429,0.94,0.528,1.556C17,8.229,17.05,8.921,17.05,9.695z M15.077,9.792c0-0.457-0.012-0.858-0.037-1.206
+		c-0.025-0.352-0.064-0.658-0.119-0.916c-0.05-0.258-0.114-0.477-0.194-0.655c-0.074-0.179-0.166-0.32-0.275-0.424
+		c-0.109-0.109-0.233-0.186-0.372-0.23c-0.139-0.045-0.293-0.067-0.461-0.067c-0.293,0-0.536,0.072-0.729,0.216
+		c-0.189,0.139-0.34,0.35-0.454,0.633c-0.109,0.283-0.187,0.635-0.231,1.057s-0.067,0.914-0.067,1.474
+		c0,0.685,0.027,1.253,0.082,1.705c0.054,0.447,0.139,0.804,0.253,1.072c0.119,0.263,0.271,0.449,0.454,0.558
+		c0.184,0.104,0.404,0.157,0.663,0.157c0.193,0,0.365-0.03,0.514-0.089c0.149-0.065,0.278-0.159,0.387-0.283
+		c0.114-0.124,0.208-0.28,0.283-0.469c0.074-0.189,0.134-0.407,0.179-0.655c0.049-0.248,0.082-0.528,0.097-0.841
+		C15.067,10.514,15.077,10.169,15.077,9.792z"/>
+	</g>
+	<g id="text4803-5-0-0">
+		<path id="path943" fill="#FFFFFF" d="M53.836,14.069c0,0.139-0.008,0.258-0.021,0.357c-0.016,0.094-0.038,0.171-0.068,0.23
+		c-0.023,0.055-0.054,0.094-0.089,0.119c-0.034,0.025-0.074,0.037-0.118,0.037h-5.316c-0.039,0-0.076-0.012-0.111-0.037
+		s-0.066-0.064-0.097-0.119c-0.024-0.06-0.045-0.136-0.06-0.23c-0.015-0.1-0.022-0.219-0.022-0.357c0-0.144,0.005-0.263,0.015-0.357
+		c0.016-0.099,0.035-0.179,0.061-0.238c0.029-0.06,0.062-0.102,0.096-0.126c0.035-0.03,0.074-0.044,0.119-0.044h1.795V7.034
+		L48.469,7.89c-0.114,0.055-0.209,0.089-0.283,0.104c-0.069,0.01-0.126-0.005-0.171-0.044c-0.04-0.045-0.067-0.119-0.082-0.224
+		c-0.015-0.104-0.022-0.25-0.022-0.439c0-0.119,0.003-0.216,0.008-0.291c0.005-0.079,0.018-0.146,0.037-0.201
+		c0.02-0.054,0.047-0.099,0.082-0.134s0.082-0.072,0.141-0.112l2.07-1.34c0.025-0.02,0.055-0.035,0.09-0.044
+		c0.039-0.015,0.089-0.025,0.148-0.03c0.06-0.01,0.137-0.015,0.23-0.015c0.1-0.005,0.227-0.007,0.38-0.007
+		c0.188,0,0.34,0.005,0.454,0.015c0.119,0.005,0.209,0.018,0.268,0.038c0.061,0.015,0.1,0.037,0.119,0.067s0.03,0.067,0.03,0.112
+		v7.958h1.57c0.045,0,0.085,0.015,0.119,0.044c0.04,0.025,0.072,0.067,0.097,0.126c0.03,0.06,0.05,0.139,0.061,0.238
+		C53.828,13.806,53.836,13.925,53.836,14.069L53.836,14.069z"/>
+	</g>
+	<path fill="none" d="z"/>
 </svg>

--- a/styles/z-bolt/images/move.svg
+++ b/styles/z-bolt/images/move.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+	xmlns:dc="http://purl.org/dc/elements/1.1/"
+	xmlns:cc="http://creativecommons.org/ns#"
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:svg="http://www.w3.org/2000/svg"
+	xmlns="http://www.w3.org/2000/svg"
+	xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+	xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="64"
    height="64"
    viewBox="0 0 64 64"
@@ -14,21 +14,21 @@
    id="svg10"
    sodipodi:docname="move.svg"
    inkscape:version="1.0.2 (e86c870879, 2021-01-15, custom)">
-  <metadata
+	<metadata
      id="metadata16">
-    <rdf:RDF>
-      <cc:Work
+		<rdf:RDF>
+			<cc:Work
          rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
+				<dc:format>image/svg+xml</dc:format>
+				<dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title>folder</dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <defs
+				<dc:title>folder</dc:title>
+			</cc:Work>
+		</rdf:RDF>
+	</metadata>
+	<defs
      id="defs14" />
-  <sodipodi:namedview
+	<sodipodi:namedview
      pagecolor="#bfbfbf"
      bordercolor="#666666"
      borderopacity="1"
@@ -42,45 +42,78 @@
      id="namedview12"
      showgrid="false"
      inkscape:pagecheckerboard="false"
-     inkscape:zoom="7.6562596"
-     inkscape:cx="37.078187"
-     inkscape:cy="31.162703"
+     inkscape:zoom="5.4137931"
+     inkscape:cx="32.109123"
+     inkscape:cy="22.356606"
      inkscape:window-x="-8"
      inkscape:window-y="-8"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg10"
      inkscape:snap-bbox="true"
      inkscape:snap-bbox-edge-midpoints="true"
-     inkscape:document-rotation="0" />
-  <!-- Generator: Sketch 52.5 (67469) - http://www.bohemiancoding.com/sketch -->
-  <title
+     inkscape:document-rotation="0"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-midpoints="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:bbox-nodes="true"
+     inkscape:bbox-paths="true" />
+	<!-- Generator: Sketch 52.5 (67469) - http://www.bohemiancoding.com/sketch -->
+	<title
      id="title2">folder</title>
-  <desc
+	<desc
      id="desc4">Created with Sketch.</desc>
-  <path
-     style="display:inline;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="M 43.907394,13.521246 32.062139,1.4999324 20.092606,13.396431 l 4.738365,4.808528 3.835042,-3.811793 -0.159334,14.029683 6.735339,0.07716 0.158928,-13.994012 3.718631,3.774116 z"
-     id="path7561-4-3"
-     inkscape:connector-curvature="0" />
-  <path
-     style="display:inline;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="M 43.907394,50.478754 32.062139,62.500068 20.092606,50.603569 l 4.738365,-4.808528 3.835042,3.811793 -0.159334,-14.029683 6.735339,-0.07716 0.158928,13.994012 3.718631,-3.774116 z"
-     id="path832"
-     inkscape:connector-curvature="0" />
-  <path
-     style="display:inline;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="M 50.478754,20.092606 62.500068,31.937861 50.603569,43.907394 45.79504,39.169029 49.606834,35.333987 35.577151,35.493321 35.499991,28.757982 49.494003,28.599054 45.719887,24.880423 Z"
-     id="path834"
-     inkscape:connector-curvature="0" />
-  <path
-     style="display:inline;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="M 13.521246,20.092606 1.4999324,31.937861 13.396431,43.907394 l 4.808529,-4.738365 -3.811794,-3.835042 14.029683,0.159334 0.07716,-6.735339 -13.994012,-0.158928 3.774116,-3.718631 z"
-     id="path836"
-     inkscape:connector-curvature="0" />
-  <circle
-     style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:#232323;fill-opacity:1;stroke:#ffffff;stroke-width:2.99999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal;stop-color:#000000;stop-opacity:1"
-     id="path838"
-     cx="32"
-     cy="32"
-     r="6" />
+	<path fill="none" d="z"/>
+	<path fill="none" d="M34.84,50.886c-0.563-0.227-0.933-0.77-0.939-1.375l-0.142-12.494l-3.735,0.043l0.142,12.531
+	c0.007,0.608-0.355,1.161-0.916,1.398c-0.562,0.235-1.209,0.11-1.642-0.318l-2.767-2.75l-2.632,2.672l9.841,9.781l9.739-9.885
+	l-2.66-2.644l-2.661,2.701C36.044,50.979,35.399,51.112,34.84,50.886z"/>
+	<path fill="none" d="M29.25,13.011c0.561,0.237,0.923,0.79,0.916,1.399l-0.142,12.53l3.735,0.043L33.9,14.489
+	c0.007-0.605,0.377-1.147,0.939-1.374c0.561-0.227,1.204-0.093,1.629,0.338l2.661,2.701l2.661-2.645l-9.74-9.884l-9.841,9.782
+	l2.633,2.671l2.766-2.75C28.042,12.901,28.69,12.775,29.25,13.011z"/>
+	<path fill="none" d="M13.115,29.16c-0.227-0.562-0.093-1.205,0.338-1.629l2.701-2.662l-2.644-2.66l-9.884,9.74l9.782,9.841
+	l2.671-2.632l-2.75-2.767c-0.429-0.432-0.555-1.081-0.318-1.642c0.235-0.556,0.78-0.916,1.382-0.916c0.005,0,0.011,0,0.017,0
+	l12.53,0.143l0.043-3.736l-12.494-0.142C13.883,30.092,13.341,29.722,13.115,29.16z"/>
+	<path fill="none" d="M47.846,24.869l2.701,2.662c0.432,0.425,0.564,1.068,0.339,1.629c-0.227,0.562-0.769,0.932-1.375,0.939
+	l-12.494,0.142l0.043,3.736l12.531-0.143c0.005,0,0.011,0,0.017,0c0.603,0,1.146,0.36,1.382,0.916
+	c0.237,0.561,0.111,1.21-0.318,1.642l-2.75,2.767l2.672,2.632l9.781-9.841l-9.885-9.74L47.846,24.869z"/>
+	<path fill="#FFFFFF" d="M29.573,27.709c0.09,0.092,0.163,0.198,0.226,0.309c0.656-0.364,1.399-0.589,2.202-0.589
+	s1.546,0.225,2.202,0.589c0.063-0.111,0.135-0.217,0.226-0.309c0.277-0.285,0.657-0.447,1.056-0.452l1.273-0.015l0.103-9.119
+	l1.191,1.209c0.28,0.284,0.661,0.445,1.061,0.447c0.357-0.016,0.782-0.155,1.065-0.436l4.788-4.759
+	c0.586-0.583,0.591-1.528,0.011-2.117L33.131,0.447C32.851,0.163,32.469,0.002,32.07,0c-0.403-0.049-0.783,0.155-1.065,0.436
+	L19.035,12.333c-0.585,0.583-0.59,1.528-0.011,2.117l4.738,4.809c0.28,0.284,0.662,0.445,1.061,0.447c0.002,0,0.005,0,0.008,0
+	c0.396,0,0.776-0.157,1.058-0.436l1.236-1.229l-0.104,9.2l1.497,0.017C28.915,27.262,29.294,27.425,29.573,27.709z M24.842,16.079
+	l-2.633-2.671l9.841-9.782l9.74,9.884l-2.661,2.645l-2.661-2.701c-0.425-0.432-1.068-0.565-1.629-0.338
+	c-0.563,0.227-0.933,0.769-0.939,1.374l-0.142,12.494l-3.735-0.043l0.142-12.53c0.007-0.609-0.355-1.162-0.916-1.399
+	c-0.56-0.236-1.208-0.11-1.642,0.318L24.842,16.079z"/>
+	<path fill="#FFFFFF" d="M35.577,36.993c-0.649,0-1.198-0.415-1.406-0.995C33.522,36.352,32.79,36.57,32,36.57
+	c-0.791,0-1.522-0.219-2.171-0.572c-0.208,0.58-0.757,0.995-1.406,0.995c-0.006,0-0.012,0-0.018,0l-1.383-0.016l0.102,8.982
+	l-1.236-1.229c-0.281-0.279-0.662-0.437-1.058-0.437c-0.002,0-0.005,0-0.008,0c-0.399,0.002-0.781,0.163-1.061,0.447l-4.738,4.809
+	c-0.58,0.588-0.575,1.534,0.011,2.116l11.969,11.896C31.286,63.844,31.666,64,32.062,64c0.002,0,0.005,0,0.008,0
+	c0.399-0.002,0.781-0.163,1.061-0.447l11.845-12.021c0.58-0.588,0.575-1.534-0.011-2.116l-4.788-4.759
+	c-0.283-0.282-0.705-0.458-1.065-0.437c-0.399,0.002-0.78,0.163-1.061,0.447l-1.191,1.209l-0.101-8.896l-1.165,0.014
+	C35.589,36.993,35.583,36.993,35.577,36.993z M39.13,47.846l2.66,2.644l-9.739,9.885l-9.841-9.781l2.632-2.672l2.767,2.75
+	c0.432,0.429,1.08,0.554,1.642,0.318c0.561-0.237,0.923-0.79,0.916-1.398L30.024,37.06l3.735-0.043L33.9,49.511
+	c0.007,0.605,0.377,1.148,0.939,1.375c0.56,0.227,1.204,0.094,1.629-0.339L39.13,47.846z"/>
+	<path fill="#FFFFFF" d="M63.553,30.87L51.531,19.024c-0.588-0.58-1.534-0.573-2.116,0.011l-4.759,4.788
+	c-0.281,0.283-0.438,0.667-0.437,1.065s0.163,0.781,0.447,1.061l1.209,1.191l-9.119,0.103l-1.273,0.015
+	c-0.398,0.004-0.778,0.167-1.056,0.452c-0.091,0.092-0.163,0.198-0.226,0.309c1.405,0.779,2.368,2.26,2.368,3.981
+	c0,1.734-0.977,3.224-2.399,3.998c0.208,0.58,0.757,0.995,1.406,0.995c0.006,0,0.012,0,0.017,0l1.165-0.014l9.201-0.104
+	l-1.229,1.236c-0.281,0.283-0.438,0.666-0.437,1.065c0.002,0.398,0.163,0.78,0.447,1.061l4.809,4.738
+	c0.292,0.288,0.673,0.432,1.053,0.432c0.386,0,0.771-0.147,1.063-0.442l11.896-11.97c0.281-0.282,0.438-0.666,0.437-1.065
+	S63.837,31.149,63.553,30.87z M50.593,41.79l-2.672-2.632l2.75-2.767c0.43-0.432,0.556-1.081,0.318-1.642
+	c-0.235-0.556-0.779-0.916-1.382-0.916c-0.006,0-0.012,0-0.017,0L37.06,33.977l-0.043-3.736l12.494-0.142
+	c0.606-0.007,1.148-0.377,1.375-0.939c0.226-0.562,0.093-1.205-0.339-1.629l-2.701-2.662l2.644-2.66l9.885,9.74L50.593,41.79z"/>
+	<path fill="#FFFFFF" d="M28.423,36.993c0.649,0,1.197-0.415,1.406-0.995C28.406,35.224,27.43,33.734,27.43,32
+	c0-1.721,0.963-3.202,2.369-3.981c-0.063-0.111-0.135-0.217-0.226-0.309c-0.278-0.285-0.658-0.447-1.056-0.452l-1.497-0.017
+	l-8.896-0.101l1.209-1.191c0.284-0.28,0.445-0.662,0.447-1.061s-0.155-0.782-0.436-1.065l-4.759-4.788
+	c-0.582-0.586-1.529-0.591-2.117-0.011L0.447,30.87C0.163,31.149,0.002,31.531,0,31.93s0.155,0.783,0.436,1.065l11.896,11.97
+	c0.293,0.295,0.679,0.442,1.064,0.442c0.38,0,0.761-0.144,1.053-0.432l4.809-4.738c0.284-0.28,0.445-0.662,0.447-1.061
+	c0.002-0.399-0.155-0.782-0.436-1.065l-1.229-1.236l8.982,0.103l1.383,0.016C28.412,36.993,28.417,36.993,28.423,36.993z
+	 M26.94,33.977l-12.53-0.143c-0.006,0-0.012,0-0.017,0c-0.602,0-1.147,0.36-1.382,0.916c-0.237,0.561-0.111,1.21,0.318,1.642
+	l2.75,2.767l-2.671,2.632l-9.782-9.841l9.884-9.74l2.644,2.66l-2.701,2.662c-0.432,0.425-0.565,1.068-0.338,1.629
+	s0.769,0.932,1.374,0.939l12.494,0.142L26.94,33.977z"/>
+	<path fill="#FFFFFF" d="M32,24.5c-4.136,0-7.5,3.364-7.5,7.5s3.364,7.5,7.5,7.5s7.5-3.364,7.5-7.5S36.136,24.5,32,24.5z M32,36.57
+	c-2.524,0-4.57-2.046-4.57-4.57c0-2.524,2.046-4.57,4.57-4.57c2.524,0,4.57,2.046,4.57,4.57C36.57,34.524,34.524,36.57,32,36.57z"/>
 </svg>


### PR DESCRIPTION
Fixed the opacity of a few images from the z-bolt style/images folder. Tested locally without any issues. 