### PR TITLE
fix: handle invalid UTF-8 characters in WiFi SSID

### DIFF
--- a/ks_includes/sdbus_nm.py
+++ b/ks_includes/sdbus_nm.py
@@ -176,8 +176,8 @@ class SdbusNm:
             all_aps = [AccessPoint(result) for result in self.wlan_device.access_points]
             networks.extend(
                 {
-                    "SSID": ap.ssid.decode("utf-8"),
-                    "known": self.is_known(ap.ssid.decode("utf-8")),
+                    "SSID": ap.ssid.decode("utf-8", errors='ignore'),
+                    "known": self.is_known(ap.ssid.decode("utf-8", errors='ignore')),
                     "security": get_encryption(
                         ap.rsn_flags or ap.wpa_flags or ap.flags
                     ),
@@ -236,7 +236,7 @@ class SdbusNm:
             },
             "802-11-wireless": {
                 "mode": ("s", "infrastructure"),
-                "ssid": ("ay", ssid.encode("utf-8")),
+                "ssid": ("ay", ssid.encode("utf-8", errors='ignore')),
                 "security": ("s", "802-11-wireless-security"),
             },
             "ipv4": {"method": ("s", "auto")},


### PR DESCRIPTION
Title:
  fix: handle invalid UTF-8 characters in WiFi SSID

  Description:
  ## Summary
  Fix crash when encountering WiFi SSIDs with invalid UTF-8 characters by adding error handling to encoding/decoding operations.

  ## Changes
  - Added `errors='ignore'` parameter to SSID `decode()` operations (2 locations)
  - Added `errors='ignore'` parameter to SSID `encode()` operation (1 location)

  ## Problem
  Some WiFi access points may have SSIDs containing invalid UTF-8 byte sequences, which causes Python's default strict UTF-8 decoder to raise `UnicodeDecodeError`,
   crashing the application.

  ## Solution
  Use the `errors='ignore'` parameter to skip malformed bytes instead of raising exceptions, ensuring the application remains stable when scanning networks with
  non-standard SSIDs.

  ## Test Plan
  - [x] Tested with WiFi networks containing invalid UTF-8 characters
  - [x] Verified no regression with standard UTF-8 SSIDs
  - [x] Application no longer crashes during network scanning