### PR TITLE
feat: Allow buttons to be focused

### DIFF
--- a/ks_includes/KlippyGtk.py
+++ b/ks_includes/KlippyGtk.py
@@ -166,7 +166,7 @@ class KlippyGtk:
     def Button(self, image_name=None, label=None, style=None, scale=None, position=Gtk.PositionType.TOP, lines=2):
         if self.font_size_type == "max" and label is not None:
             image_name = None
-        b = Gtk.Button(hexpand=True, vexpand=True, can_focus=False, image_position=position, always_show_image=True)
+        b = Gtk.Button(hexpand=True, vexpand=True, can_focus=True, image_position=position, always_show_image=True)
         if label is not None:
             b.set_label(label.replace("\n", " "))
         if image_name is not None:


### PR DESCRIPTION
This allows elements to be focused by pressing tab or shift-tab, and selected with enter or space.

The motivation for this is to be able to use a rotary encoder on my LCD display panel to navigate KlipperScreen. A bit more background and an example video is at
https://github.com/KlipperScreen/KlipperScreen/discussions/1549

I haven't found any side effects which otherwise impacts touchscreen use.