### PR TITLE
Fix vertical mode not updating properly on screen size change

### DIFF
--- a/screen.py
+++ b/screen.py
@@ -1316,10 +1316,10 @@ class KlipperScreen(Gtk.Window):
         new_mode = new_ratio < 1.0
         ratio_delta = abs(self.aspect_ratio - new_ratio)
         if ratio_delta > 0.1 and self.vertical_mode != new_mode:
-            self.reload_panels()
             self.vertical_mode = new_mode
             self.aspect_ratio = new_ratio
             logging.info(f"Vertical mode: {self.vertical_mode}")
+            self.reload_panels()
 
 
 def main():


### PR DESCRIPTION
There was already logic in place to handle changes in screen size, including updating the displayed panels and recalculating `self.vertical_mode`. However `vertical_mode` is only being updated _after_ the panels have already been re-created. As such, the displayed layout keeps its previous vertical mode whenever the display orientation changes, causing e.g. the old horizontal layout being crammed onto a now-vertical screen.

Fix this by just updating `self.vertical_mode` _before_ re-creating the panels. Same for `aspect_ratio`, so this might also fix issues with the screen's aspect ratio somehow changing.

This is needed when e.g. using Wayland/cage as the compositor, which doesn't allow starting with a predefined orientation and instead wants you to change the display orientation post-launch ([ref](https://github.com/cage-kiosk/cage/issues/276)). As such, the vertical mode needs to change dynamically. For some reason (I'm not a Wayland expert so maybe that's intended) a `video=<...>,rotate=90` kernel cmdline flag seems to be ignored by Cage as well, always starting in the display's native orientation.