### PR TITLE
system panel: fix label formatting for IP address

### DIFF
--- a/panels/system.py
+++ b/panels/system.py
@@ -139,7 +139,7 @@ class Panel(ScreenPanel):
                             ):
                                 for _ip in sub_value:
                                     self.add_label_to_grid(
-                                        f"{self.prettify(sub_key)}: {_ip['address']}", 1
+                                        f"{_('IP Address')}: {_ip['address']}", 1
                                     )
                                 continue
                             self.add_label_to_grid(


### PR DESCRIPTION
Currently IP addresses are shown on the system page with following format: 

```
Ip Addresses: 192.168.1.1
Ip Addresses: ff:xx:etc
```
for each IP address.

This PR updates it to `IP Address: 192.168.1.1`