### PR TITLE
Exclude bad wifi interfaces

### DIFF
--- a/ks_includes/sdbus_nm.py
+++ b/ks_includes/sdbus_nm.py
@@ -130,6 +130,11 @@ class SdbusNm:
             NetworkDeviceWireless(path)
             for path, device in devices.items()
             if device.device_type == enums.DeviceType.WIFI
+            and device.state not in {
+                enums.DeviceState.UNKNOWN,
+                enums.DeviceState.UNMANAGED,
+                enums.DeviceState.UNAVAILABLE,
+            }
         ]
 
     def get_primary_interface(self):


### PR DESCRIPTION
Exclude wifi interfaces in UNKNOWN, UNMANAGED or UNAVAILABLE states

KlipperScreen selects the first Wi-Fi interface returned by NetworkManager for connecting and scanning networks. If the system has more than one Wi-Fi interface and the first one is unavailable or unmanaged, this leads to a network scan error and makes connection management completely impossible. In my case, this was the p2p interface. I propose a simple solution that filters out interfaces in unsuitable states. This is not a definitive solution for choosing between multiple interfaces, but it helps avoid the most obvious errors.