### PR TITLE
Add configurable Spoolman title bar status with low-weight alert

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -70,7 +70,7 @@ moonraker_port: 7125
 # moonraker_ssl: False
 # If you're using the route_prefix option in your moonraker config, specify it here.
 # This can be useful for running multiple printers behind a path-based reverse proxy.
-# Most installs will not need this. 
+# Most installs will not need this.
 # moonraker_path: printer1
 # Moonraker API key if this host is not connecting from a trusted client IP
 # moonraker_api_key: False
@@ -85,11 +85,10 @@ moonraker_port: 7125
 # power_devices: example1, example2
 
 # Define what items should be shown in titlebar besides the extruder and bed
-# Device names must match the names defined in the Klipper config.
-# The special item "spool" depends on Spoolman data provided through Moonraker,
-# it is not a Klipper device name.
-# valid options are device names from Klipper or the special item "spool"
-# titlebar_items: chamber, spool, MCU, Pi
+# the name must be the same as defined in the klipper config
+# valid options are temperature_sensors or temperature_fans, or heater_generic
+# There is a special item named "spool" that depends on Spoolman data provided through Moonraker
+# titlebar_items: chamber, MCU, Pi, spool
 
 # The style of the user defined items in the titlebar
 # Can be 'full' indicating that the full name is shown, 'short' for the first letter, or None (default) for no name

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -86,8 +86,8 @@ moonraker_port: 7125
 
 # Define what items should be shown in titlebar besides the extruder and bed
 # the name must be the same as defined in the klipper config
-# valid options are temperature_sensors or temperature_fans, heater_generic, or spoolman
-# titlebar_items: chamber, spoolman, MCU, Pi
+# valid options are temperature_sensors or temperature_fans, heater_generic, or spool
+# titlebar_items: chamber, spool, MCU, Pi
 
 # The style of the user defined items in the titlebar
 # Can be 'full' indicating that the full name is shown, 'short' for the first letter, or None (default) for no name
@@ -95,7 +95,7 @@ moonraker_port: 7125
 
 # Low limit for remaining spool weight in the title bar, in grams.
 # When the active spool drops below this value, the spool icon and weight blink red.
-# spoolman_low_limit: 20
+# spool_low_limit: 20
 
 # Z probe calibrate position
 # By default it tries to guess the correct location

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -85,8 +85,10 @@ moonraker_port: 7125
 # power_devices: example1, example2
 
 # Define what items should be shown in titlebar besides the extruder and bed
-# the name must be the same as defined in the klipper config
-# valid options are temperature_sensors or temperature_fans, heater_generic, or spool
+# Device names must match the names defined in the Klipper config.
+# The special item "spool" depends on Spoolman data provided through Moonraker,
+# it is not a Klipper device name.
+# valid options are device names from Klipper or the special item "spool"
 # titlebar_items: chamber, spool, MCU, Pi
 
 # The style of the user defined items in the titlebar
@@ -94,7 +96,7 @@ moonraker_port: 7125
 # titlebar_name_type: None
 
 # Low limit for remaining spool weight in the title bar, in grams.
-# When the active spool drops below this value, the spool icon and weight blink red.
+# When the active spool drops below this value, the spool icon and weight turn red.
 # spool_low_limit: 20
 
 # Z probe calibrate position

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -86,12 +86,16 @@ moonraker_port: 7125
 
 # Define what items should be shown in titlebar besides the extruder and bed
 # the name must be the same as defined in the klipper config
-# valid options are temperature_sensors or temperature_fans, or heater_generic
-# titlebar_items: chamber, MCU, Pi
+# valid options are temperature_sensors or temperature_fans, heater_generic, or spoolman
+# titlebar_items: chamber, spoolman, MCU, Pi
 
 # The style of the user defined items in the titlebar
 # Can be 'full' indicating that the full name is shown, 'short' for the first letter, or None (default) for no name
 # titlebar_name_type: None
+
+# Low limit for remaining spool weight in the title bar, in grams.
+# When the active spool drops below this value, the spool icon and weight blink red.
+# spoolman_low_limit: 20
 
 # Z probe calibrate position
 # By default it tries to guess the correct location

--- a/ks_includes/config.py
+++ b/ks_includes/config.py
@@ -195,7 +195,7 @@ class KlipperScreenConfig:
                 )
                 numbers = (
                     'moonraker_port', 'move_speed_xy', 'move_speed_z', 'screw_rotation',
-                    'calibrate_x_position', 'calibrate_y_position',
+                    'calibrate_x_position', 'calibrate_y_position', 'spoolman_low_limit',
                 )
             elif section.startswith('preheat '):
                 strs = ('gcode', '')

--- a/ks_includes/config.py
+++ b/ks_includes/config.py
@@ -195,7 +195,8 @@ class KlipperScreenConfig:
                 )
                 numbers = (
                     'moonraker_port', 'move_speed_xy', 'move_speed_z', 'screw_rotation',
-                    'calibrate_x_position', 'calibrate_y_position', 'spoolman_low_limit',
+                    'calibrate_x_position', 'calibrate_y_position', 'spool_low_limit',
+                    'spoolman_low_limit',
                 )
             elif section.startswith('preheat '):
                 strs = ('gcode', '')

--- a/ks_includes/config.py
+++ b/ks_includes/config.py
@@ -196,7 +196,6 @@ class KlipperScreenConfig:
                 numbers = (
                     'moonraker_port', 'move_speed_xy', 'move_speed_z', 'screw_rotation',
                     'calibrate_x_position', 'calibrate_y_position', 'spool_low_limit',
-                    'spoolman_low_limit',
                 )
             elif section.startswith('preheat '):
                 strs = ('gcode', '')

--- a/ks_includes/printer.py
+++ b/ks_includes/printer.py
@@ -27,6 +27,9 @@ class Printer:
         self.cameras = []
         self.available_commands = {}
         self.spoolman = False
+        self.active_spool_id = None
+        self.active_spool = None
+        self.active_spool_checked = False
         self.temp_devices = self.sensors = None
         self.system_info = {}
         self.warnings = []
@@ -48,6 +51,9 @@ class Printer:
         self.stop_tempstore_updates()
         self.system_info.clear()
         self.warnings = []
+        self.active_spool_id = None
+        self.active_spool = None
+        self.active_spool_checked = False
 
         for x in self.config.keys():
             # Support for hiding devices by name
@@ -420,3 +426,8 @@ class Printer:
     def enable_spoolman(self):
         logging.info("Enabling Spoolman")
         self.spoolman = True
+
+    def set_active_spool(self, spool_id=None, spool=None, checked=True):
+        self.active_spool_id = spool_id
+        self.active_spool = spool
+        self.active_spool_checked = checked

--- a/panels/base_panel.py
+++ b/panels/base_panel.py
@@ -421,7 +421,12 @@ class BasePanel(ScreenPanel):
 
     def process_update(self, action, data):
         if action == "notify_active_spool_set":
-            spool_id = data.get("spool_id") if isinstance(data, dict) else None
+            has_spool_id = isinstance(data, dict) and "spool_id" in data
+            if not has_spool_id and self._printer is not None:
+                # Force a refetch when the event arrives without an explicit spool_id
+                # so the titlebar doesn't keep showing a stale cached spool.
+                self._printer.set_active_spool(checked=False)
+            spool_id = data.get("spool_id") if has_spool_id else None
             self.refresh_spoolman_weight(
                 self._printer is not None
                 and self._printer.state not in {'disconnected', 'startup', 'shutdown', 'error'},

--- a/panels/base_panel.py
+++ b/panels/base_panel.py
@@ -251,7 +251,7 @@ class BasePanel(ScreenPanel):
                     self.control['temp_box'].add(self.labels[f"{device}_box"])
                     n += 1
             for item in self.titlebar_items:
-                if item == "spoolman" and self._printer.spoolman:
+                if item in {"spool", "spoolman"} and self._printer.spoolman:
                     self.control['temp_box'].add(self.control['spoolman_box'])
                     continue
                 for device in devices:
@@ -593,8 +593,11 @@ class BasePanel(ScreenPanel):
                 logging.info(f"Titlebar name type: {self.titlebar_name_type} items: {self.titlebar_items}")
             else:
                 self.titlebar_items = []
-            self.show_spoolman_in_title = "spoolman" in self.titlebar_items
-            self.spoolman_low_limit = self.ks_printer_cfg.getfloat("spoolman_low_limit", fallback=0)
+            self.show_spoolman_in_title = any(item in {"spool", "spoolman"} for item in self.titlebar_items)
+            self.spoolman_low_limit = self.ks_printer_cfg.getfloat(
+                "spool_low_limit",
+                fallback=self.ks_printer_cfg.getfloat("spoolman_low_limit", fallback=0)
+            )
         else:
             self.titlebar_items = []
             self.show_spoolman_in_title = False

--- a/panels/base_panel.py
+++ b/panels/base_panel.py
@@ -237,20 +237,15 @@ class BasePanel(ScreenPanel):
                 elif device.startswith("heater"):
                     self.control['temp_box'].add(self.labels[f"{device}_box"])
                     n += 1
-            for device in devices:
-                # Users can fill the bar if they want
-                if n >= nlimit + 1:
-                    break
-                name = device.split()[1] if len(device.split()) > 1 else device
-                for item in self.titlebar_items:
-                    if name == item:
+            for item in self.titlebar_items:
+                if item == "spoolman" and self._printer.spoolman:
+                    self.control['temp_box'].add(self.control['spoolman_box'])
+                    continue
+                for device in devices:
+                    name = device.split()[1] if len(device.split()) > 1 else device
+                    if name == item and self.labels[f"{device}_box"].get_parent() is None:
                         self.control['temp_box'].add(self.labels[f"{device}_box"])
-                        n += 1
                         break
-
-            if self.show_spoolman_in_title and self._printer.spoolman and n < nlimit + 1:
-                self.control['temp_box'].add(self.control['spoolman_box'])
-                n += 1
 
             self.control['temp_box'].show_all()
         except Exception as e:

--- a/panels/base_panel.py
+++ b/panels/base_panel.py
@@ -7,7 +7,7 @@ import re
 import gi
 
 gi.require_version("Gtk", "3.0")
-from gi.repository import GLib, Gtk, Pango, GdkPixbuf
+from gi.repository import Gio, GLib, Gtk, Pango, GdkPixbuf
 from jinja2 import Environment
 from datetime import datetime
 from math import log
@@ -115,10 +115,10 @@ class BasePanel(ScreenPanel):
 
         self.labels['spoolman_icon'] = Gtk.Image()
         self.labels['spoolman_weight'] = Gtk.Label()
-        self.control['spoolman_box'] = Gtk.Box(halign=Gtk.Align.END, spacing=1)
+        self.control['spoolman_box'] = Gtk.Box()
         self.control['spoolman_box'].set_no_show_all(True)
-        self.control['spoolman_box'].add(self.labels['spoolman_icon'])
-        self.control['spoolman_box'].add(self.labels['spoolman_weight'])
+        self.control['spoolman_box'].pack_start(self.labels['spoolman_icon'], False, False, 7)
+        self.control['spoolman_box'].pack_start(self.labels['spoolman_weight'], False, False, 0)
         self.labels['spoolman_icon'].show()
         self.labels['spoolman_weight'].show()
         self.load_spoolman_icons()
@@ -180,6 +180,20 @@ class BasePanel(ScreenPanel):
     def load_spoolman_icons(self):
         self.spoolman_icon_alert_pixbuf = self.get_spoolman_icon_pixbuf("981E1F", full_icon=True)
 
+    def get_spoolman_icon_size(self, svg):
+        match = re.search(r'viewBox="\s*[\d.]+\s+[\d.]+\s+([\d.]+)\s+([\d.]+)\s*"', svg)
+        if not match:
+            match = re.search(r'width="([\d.]+)".*height="([\d.]+)"', svg, re.DOTALL)
+        if not match:
+            return self.spoolman_icon_size, self.spoolman_icon_size
+        width = float(match.group(1))
+        height = float(match.group(2))
+        if width <= 0 or height <= 0:
+            return self.spoolman_icon_size, self.spoolman_icon_size
+        target_height = self.spoolman_icon_size
+        target_width = max(1, round(target_height * width / height))
+        return target_width, target_height
+
     def get_spoolman_icon_pixbuf(self, color, full_icon=False):
         klipperscreendir = pathlib.Path(__file__).parent.resolve().parent
         icon_path = os.path.join(klipperscreendir, "styles", self._screen.theme, "images", "spool.svg")
@@ -190,11 +204,17 @@ class BasePanel(ScreenPanel):
             svg = svg.replace("var(--filament-color)", f"#{color}")
             if full_icon:
                 svg = re.sub(r'fill:\s*(?!none)[^;"\']+', f'fill:#{color}', svg)
-            loader = GdkPixbuf.PixbufLoader()
-            loader.set_size(self.spoolman_icon_size, self.spoolman_icon_size)
-            loader.write(svg.encode())
-            loader.close()
-            return loader.get_pixbuf()
+            target_width, target_height = self.get_spoolman_icon_size(svg)
+            stream = Gio.MemoryInputStream.new_from_data(svg.encode(), None)
+            pixbuf = GdkPixbuf.Pixbuf.new_from_stream_at_scale(
+                stream,
+                target_width,
+                target_height,
+                True,
+                None,
+            )
+            stream.close_async(2)
+            return pixbuf
         except Exception as e:
             logging.error(f"Couldn't load spoolman icon: {e}")
             return self._gtk.PixbufFromIcon("spool", self.spoolman_icon_size, self.spoolman_icon_size)
@@ -339,7 +359,7 @@ class BasePanel(ScreenPanel):
                 or self._printer.active_spool["remaining_weight"] is None
         ):
             self.update_spoolman_alert_visuals(False)
-            self.labels['spoolman_weight'].set_label(" ?")
+            self.labels['spoolman_weight'].set_label("?")
             self.control['spoolman_box'].show()
             return
         remaining_weight = self._printer.active_spool["remaining_weight"]

--- a/panels/base_panel.py
+++ b/panels/base_panel.py
@@ -13,6 +13,8 @@ from datetime import datetime
 from math import log
 from ks_includes.screen_panel import ScreenPanel
 
+SPOOL_ID_UNSET = object()
+
 try:
     import psutil
     psutil_available = True
@@ -363,7 +365,7 @@ class BasePanel(ScreenPanel):
             self.update_spoolman_alert_visuals(False)
         self.control['spoolman_box'].show()
 
-    def refresh_spoolman_weight(self, show=True, spool_id=None):
+    def refresh_spoolman_weight(self, show=True, spool_id=SPOOL_ID_UNSET):
         if self._printer is None or not self.show_spoolman_in_title:
             self.stop_spoolman_blink()
             self.update_spoolman_alert_visuals(False)
@@ -378,10 +380,10 @@ class BasePanel(ScreenPanel):
             self._printer.set_active_spool(checked=False)
             self.update_spoolman_weight_label()
             return
-        if spool_id is None and self._printer.active_spool_checked:
+        if spool_id is SPOOL_ID_UNSET and self._printer.active_spool_checked:
             self.update_spoolman_weight_label()
             return
-        if spool_id is None:
+        if spool_id is SPOOL_ID_UNSET:
             result = self._screen.apiclient.send_request("server/spoolman/spool_id")
             if result is False:
                 logging.error("Error trying to fetch active spool id")
@@ -426,7 +428,7 @@ class BasePanel(ScreenPanel):
                 # Force a refetch when the event arrives without an explicit spool_id
                 # so the titlebar doesn't keep showing a stale cached spool.
                 self._printer.set_active_spool(checked=False)
-            spool_id = data.get("spool_id") if has_spool_id else None
+            spool_id = data.get("spool_id") if has_spool_id else SPOOL_ID_UNSET
             self.refresh_spoolman_weight(
                 self._printer is not None
                 and self._printer.state not in {'disconnected', 'startup', 'shutdown', 'error'},

--- a/panels/base_panel.py
+++ b/panels/base_panel.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 import logging
+import os
+import pathlib
 
 import gi
 
 gi.require_version("Gtk", "3.0")
-from gi.repository import GLib, Gtk, Pango
+from gi.repository import GLib, Gtk, Pango, GdkPixbuf
 from jinja2 import Environment
 from datetime import datetime
 from math import log
@@ -28,6 +30,13 @@ class BasePanel(ScreenPanel):
         self.battery_update = None
         self.titlebar_items = []
         self.titlebar_name_type = None
+        self.show_spoolman_in_title = False
+        self.spoolman_low_limit = 0
+        self.spoolman_blink_timeout = None
+        self.spoolman_blink_state = False
+        self.spoolman_icon_size = int(self._gtk.font_size * 1.1)
+        self.spoolman_icon_pixbuf = None
+        self.spoolman_icon_alert_pixbuf = None
         self.current_extruder = None
         self.last_usage_report = datetime.now()
         self.usage_report = 0
@@ -104,10 +113,21 @@ class BasePanel(ScreenPanel):
         for widget in self.control['battery_box']:
             widget.show()
 
+        self.labels['spoolman_icon'] = Gtk.Image()
+        self.labels['spoolman_weight'] = Gtk.Label()
+        self.control['spoolman_box'] = Gtk.Box(halign=Gtk.Align.END, spacing=4)
+        self.control['spoolman_box'].set_no_show_all(True)
+        self.control['spoolman_box'].add(self.labels['spoolman_icon'])
+        self.control['spoolman_box'].add(self.labels['spoolman_weight'])
+        self.labels['spoolman_icon'].show()
+        self.labels['spoolman_weight'].show()
+        self.load_spoolman_icons()
+
         self.titlebar = Gtk.Box(spacing=5, valign=Gtk.Align.CENTER)
         self.titlebar.get_style_context().add_class("title_bar")
         self.titlebar.add(self.control['temp_box'])
         self.titlebar.add(self.titlelbl)
+        self.titlebar.add(self.control['spoolman_box'])
         self.titlebar.add(self.control['time_box'])
         self.titlebar.add(self.control['battery_box'])
         self.set_title(title)
@@ -156,6 +176,30 @@ class BasePanel(ScreenPanel):
 
         self.battery_icons = self.load_battery_icons()
         self.battery_percentage()
+        self.load_spoolman_icons()
+        self.update_spoolman_alert_visuals(self.spoolman_blink_state)
+
+    def load_spoolman_icons(self):
+        self.spoolman_icon_pixbuf = self.get_spoolman_icon_pixbuf("FFFFFF")
+        self.spoolman_icon_alert_pixbuf = self.get_spoolman_icon_pixbuf("981E1F")
+        self.labels['spoolman_icon'].set_from_pixbuf(self.spoolman_icon_pixbuf)
+
+    def get_spoolman_icon_pixbuf(self, color):
+        klipperscreendir = pathlib.Path(__file__).parent.resolve().parent
+        icon_path = os.path.join(klipperscreendir, "styles", self._screen.theme, "images", "spool.svg")
+        if not os.path.isfile(icon_path):
+            icon_path = os.path.join(klipperscreendir, "styles", "spool.svg")
+        try:
+            svg = pathlib.Path(icon_path).read_text(encoding="utf-8")
+            svg = svg.replace("var(--filament-color)", f"#{color}")
+            loader = GdkPixbuf.PixbufLoader()
+            loader.set_size(self.spoolman_icon_size, self.spoolman_icon_size)
+            loader.write(svg.encode())
+            loader.close()
+            return loader.get_pixbuf()
+        except Exception as e:
+            logging.error(f"Couldn't load spoolman icon: {e}")
+            return self._gtk.PixbufFromIcon("spool", self.spoolman_icon_size, self.spoolman_icon_size)
 
     def show_heaters(self, show=True):
         for child in self.control['temp_box'].get_children():
@@ -242,12 +286,95 @@ class BasePanel(ScreenPanel):
         self.control['shutdown'].set_visible(not printing)
         self.show_shortcut(connected and printer_select)
         self.show_heaters(connected and printer_select)
+        self.refresh_spoolman_weight(connected and printer_select)
         self.show_printer_select(len(self._config.get_printers()) > 1)
         for control in ('back', 'home'):
             self.set_control_sensitive(len(self._screen._cur_panels) > 1, control=control)
         self.current_panel = panel
         self.set_title(panel.title)
         self.content.add(panel.content)
+
+    def stop_spoolman_blink(self):
+        if self.spoolman_blink_timeout is not None:
+            GLib.source_remove(self.spoolman_blink_timeout)
+            self.spoolman_blink_timeout = None
+        self.spoolman_blink_state = False
+
+    def update_spoolman_alert_visuals(self, alert):
+        if alert:
+            self.labels['spoolman_icon'].set_from_pixbuf(self.spoolman_icon_alert_pixbuf)
+            self.labels['spoolman_weight'].get_style_context().add_class("spoolman_low")
+        else:
+            self.labels['spoolman_icon'].set_from_pixbuf(self.spoolman_icon_pixbuf)
+            self.labels['spoolman_weight'].get_style_context().remove_class("spoolman_low")
+
+    def blink_spoolman_low(self):
+        self.spoolman_blink_state = not self.spoolman_blink_state
+        self.update_spoolman_alert_visuals(self.spoolman_blink_state)
+        return True
+
+    def update_spoolman_weight_label(self):
+        if (
+                self._printer is None
+                or not self._printer.spoolman
+                or not self.show_spoolman_in_title
+                or not self._printer.active_spool
+                or "remaining_weight" not in self._printer.active_spool
+                or self._printer.active_spool["remaining_weight"] is None
+        ):
+            self.stop_spoolman_blink()
+            self.update_spoolman_alert_visuals(False)
+            self.control['spoolman_box'].hide()
+            return
+        remaining_weight = self._printer.active_spool["remaining_weight"]
+        self.labels['spoolman_weight'].set_label(f'{round(remaining_weight):.0f}g')
+        if self.spoolman_low_limit > 0 and remaining_weight < self.spoolman_low_limit:
+            if self.spoolman_blink_timeout is None:
+                self.spoolman_blink_state = True
+                self.update_spoolman_alert_visuals(True)
+                self.spoolman_blink_timeout = GLib.timeout_add(700, self.blink_spoolman_low)
+        else:
+            self.stop_spoolman_blink()
+            self.update_spoolman_alert_visuals(False)
+        self.control['spoolman_box'].show()
+
+    def refresh_spoolman_weight(self, show=True, spool_id=None):
+        if self._printer is None or not self._printer.spoolman or not self.show_spoolman_in_title or not show:
+            self.stop_spoolman_blink()
+            self.update_spoolman_alert_visuals(False)
+            self.control['spoolman_box'].hide()
+            return
+        if spool_id is None and self._printer.active_spool_checked:
+            self.update_spoolman_weight_label()
+            return
+        if spool_id is None:
+            result = self._screen.apiclient.send_request("server/spoolman/spool_id")
+            if result is False:
+                logging.error("Error trying to fetch active spool id")
+                self._printer.set_active_spool(checked=False)
+                self.update_spoolman_weight_label()
+                return
+            if "spool_id" not in result or not result["spool_id"]:
+                self._printer.set_active_spool()
+                self.update_spoolman_weight_label()
+                return
+            spool_id = result["spool_id"]
+        elif not spool_id:
+            self._printer.set_active_spool()
+            self.update_spoolman_weight_label()
+            return
+
+        spool = self._screen.apiclient.post_request("server/spoolman/proxy", json={
+            "request_method": "GET",
+            "path": f"/v1/spool/{spool_id}",
+        })
+        if not spool or "result" not in spool:
+            logging.error("Error trying to fetch active spool information")
+            self._printer.set_active_spool(spool_id=spool_id, checked=False)
+            self.update_spoolman_weight_label()
+            return
+        self._printer.set_active_spool(spool_id=spool_id, spool=spool["result"])
+        self.update_spoolman_weight_label()
 
     def back(self, widget=None):
         if self.current_panel is None:
@@ -259,6 +386,13 @@ class BasePanel(ScreenPanel):
             self._screen._menu_go_back()
 
     def process_update(self, action, data):
+        if action == "notify_active_spool_set":
+            spool_id = data.get("spool_id") if isinstance(data, dict) else None
+            self.refresh_spoolman_weight(
+                self._printer is not None and self._printer.state not in {'disconnected', 'startup', 'shutdown', 'error'},
+                spool_id=spool_id
+            )
+            return
         if action == "notify_proc_stat_update":
             cpu = data["system_cpu_usage"]["cpu"]
             memory = (data["system_memory"]["used"] / data["system_memory"]["total"]) * 100
@@ -428,6 +562,15 @@ class BasePanel(ScreenPanel):
                 logging.info(f"Titlebar name type: {self.titlebar_name_type} items: {self.titlebar_items}")
             else:
                 self.titlebar_items = []
+            self.show_spoolman_in_title = "spoolman" in self.titlebar_items
+            self.spoolman_low_limit = self.ks_printer_cfg.getfloat("spoolman_low_limit", fallback=0)
+        else:
+            self.titlebar_items = []
+            self.show_spoolman_in_title = False
+            self.spoolman_low_limit = 0
+        self.refresh_spoolman_weight(
+            self._printer is not None and self._printer.state not in {'disconnected', 'startup', 'shutdown', 'error'}
+        )
 
     def show_update_dialog(self):
         if self.update_dialog is not None:

--- a/panels/base_panel.py
+++ b/panels/base_panel.py
@@ -251,7 +251,7 @@ class BasePanel(ScreenPanel):
                     self.control['temp_box'].add(self.labels[f"{device}_box"])
                     n += 1
             for item in self.titlebar_items:
-                if item in {"spool", "spoolman"} and self._printer.spoolman:
+                if item == "spool" and self._printer.spoolman:
                     self.control['temp_box'].add(self.control['spoolman_box'])
                     continue
                 for device in devices:
@@ -593,11 +593,8 @@ class BasePanel(ScreenPanel):
                 logging.info(f"Titlebar name type: {self.titlebar_name_type} items: {self.titlebar_items}")
             else:
                 self.titlebar_items = []
-            self.show_spoolman_in_title = any(item in {"spool", "spoolman"} for item in self.titlebar_items)
-            self.spoolman_low_limit = self.ks_printer_cfg.getfloat(
-                "spool_low_limit",
-                fallback=self.ks_printer_cfg.getfloat("spoolman_low_limit", fallback=0)
-            )
+            self.show_spoolman_in_title = "spool" in self.titlebar_items
+            self.spoolman_low_limit = self.ks_printer_cfg.getfloat("spool_low_limit", fallback=0)
         else:
             self.titlebar_items = []
             self.show_spoolman_in_title = False

--- a/panels/base_panel.py
+++ b/panels/base_panel.py
@@ -2,6 +2,7 @@
 import logging
 import os
 import pathlib
+import re
 
 import gi
 
@@ -188,9 +189,7 @@ class BasePanel(ScreenPanel):
             svg = pathlib.Path(icon_path).read_text(encoding="utf-8")
             svg = svg.replace("var(--filament-color)", f"#{color}")
             if full_icon:
-                svg = svg.replace("fill:#ffffff", f"fill:#{color}")
-                svg = svg.replace("fill:#343434", f"fill:#{color}")
-                svg = svg.replace("fill:#111", f"fill:#{color}")
+                svg = re.sub(r'fill:\s*(?!none)[^;"\']+', f'fill:#{color}', svg)
             loader = GdkPixbuf.PixbufLoader()
             loader.set_size(self.spoolman_icon_size, self.spoolman_icon_size)
             loader.write(svg.encode())

--- a/panels/base_panel.py
+++ b/panels/base_panel.py
@@ -177,9 +177,9 @@ class BasePanel(ScreenPanel):
         self.update_spoolman_alert_visuals(self.spoolman_blink_state)
 
     def load_spoolman_icons(self):
-        self.spoolman_icon_alert_pixbuf = self.get_spoolman_icon_pixbuf("981E1F")
+        self.spoolman_icon_alert_pixbuf = self.get_spoolman_icon_pixbuf("981E1F", full_icon=True)
 
-    def get_spoolman_icon_pixbuf(self, color):
+    def get_spoolman_icon_pixbuf(self, color, full_icon=False):
         klipperscreendir = pathlib.Path(__file__).parent.resolve().parent
         icon_path = os.path.join(klipperscreendir, "styles", self._screen.theme, "images", "spool.svg")
         if not os.path.isfile(icon_path):
@@ -187,6 +187,10 @@ class BasePanel(ScreenPanel):
         try:
             svg = pathlib.Path(icon_path).read_text(encoding="utf-8")
             svg = svg.replace("var(--filament-color)", f"#{color}")
+            if full_icon:
+                svg = svg.replace("fill:#ffffff", f"fill:#{color}")
+                svg = svg.replace("fill:#343434", f"fill:#{color}")
+                svg = svg.replace("fill:#111", f"fill:#{color}")
             loader = GdkPixbuf.PixbufLoader()
             loader.set_size(self.spoolman_icon_size, self.spoolman_icon_size)
             loader.write(svg.encode())

--- a/panels/base_panel.py
+++ b/panels/base_panel.py
@@ -115,7 +115,7 @@ class BasePanel(ScreenPanel):
 
         self.labels['spoolman_icon'] = Gtk.Image()
         self.labels['spoolman_weight'] = Gtk.Label()
-        self.control['spoolman_box'] = Gtk.Box(halign=Gtk.Align.END, spacing=4)
+        self.control['spoolman_box'] = Gtk.Box(halign=Gtk.Align.END, spacing=1)
         self.control['spoolman_box'].set_no_show_all(True)
         self.control['spoolman_box'].add(self.labels['spoolman_icon'])
         self.control['spoolman_box'].add(self.labels['spoolman_weight'])

--- a/panels/base_panel.py
+++ b/panels/base_panel.py
@@ -34,7 +34,7 @@ class BasePanel(ScreenPanel):
         self.titlebar_items = []
         self.titlebar_name_type = None
         self.show_spoolman_in_title = False
-        self.spoolman_low_limit = 0
+        self.spoolman_low_limit = 20
         self.spoolman_icon_size = self._gtk.img_scale * self.bts * .9
         self.spoolman_icon_alert_pixbuf = None
         self.current_extruder = None
@@ -364,9 +364,7 @@ class BasePanel(ScreenPanel):
             return
         remaining_weight = self._printer.active_spool["remaining_weight"]
         self.labels['spoolman_weight'].set_label(f'{round(remaining_weight):.0f} g')
-        self.update_spoolman_alert_visuals(
-            self.spoolman_low_limit > 0 and remaining_weight < self.spoolman_low_limit
-        )
+        self.update_spoolman_alert_visuals(remaining_weight < self.spoolman_low_limit)
         self.control['spoolman_box'].show()
 
     def refresh_spoolman_weight(self, show=True, spool_id=SPOOL_ID_UNSET):
@@ -607,11 +605,11 @@ class BasePanel(ScreenPanel):
             else:
                 self.titlebar_items = []
             self.show_spoolman_in_title = "spool" in self.titlebar_items
-            self.spoolman_low_limit = self.ks_printer_cfg.getfloat("spool_low_limit", fallback=0)
+            self.spoolman_low_limit = self.ks_printer_cfg.getfloat("spool_low_limit", fallback=20)
         else:
             self.titlebar_items = []
             self.show_spoolman_in_title = False
-            self.spoolman_low_limit = 0
+            self.spoolman_low_limit = 20
         self.refresh_spoolman_weight(
             self._printer is not None and self._printer.state not in {'disconnected', 'startup', 'shutdown', 'error'}
         )

--- a/panels/base_panel.py
+++ b/panels/base_panel.py
@@ -35,7 +35,7 @@ class BasePanel(ScreenPanel):
         self.titlebar_name_type = None
         self.show_spoolman_in_title = False
         self.spoolman_low_limit = 0
-        self.spoolman_icon_size = int(self._gtk.font_size * 1.1)
+        self.spoolman_icon_size = self._gtk.img_scale * self.bts * .9
         self.spoolman_icon_alert_pixbuf = None
         self.current_extruder = None
         self.last_usage_report = datetime.now()
@@ -191,7 +191,7 @@ class BasePanel(ScreenPanel):
             if full_icon:
                 svg = re.sub(r'fill:\s*(?!none)[^;"\']+', f'fill:#{color}', svg)
             loader = GdkPixbuf.PixbufLoader()
-            loader.set_size(self.spoolman_icon_size, self.spoolman_icon_size)
+            loader.set_size(self.spoolman_icon_size)
             loader.write(svg.encode())
             loader.close()
             return loader.get_pixbuf()
@@ -254,7 +254,8 @@ class BasePanel(ScreenPanel):
                     self.control['temp_box'].add(self.labels[f"{device}_box"])
                     n += 1
             for item in self.titlebar_items:
-                if n >= nlimit:
+                # Users can fill the bar if they want
+                if n >= nlimit + 1:
                     break
                 if item == "spool" and self._printer.spoolman:
                     self.control['temp_box'].add(self.control['spoolman_box'])

--- a/panels/base_panel.py
+++ b/panels/base_panel.py
@@ -191,7 +191,7 @@ class BasePanel(ScreenPanel):
             if full_icon:
                 svg = re.sub(r'fill:\s*(?!none)[^;"\']+', f'fill:#{color}', svg)
             loader = GdkPixbuf.PixbufLoader()
-            loader.set_size(self.spoolman_icon_size)
+            loader.set_size(self.spoolman_icon_size, self.spoolman_icon_size)
             loader.write(svg.encode())
             loader.close()
             return loader.get_pixbuf()
@@ -343,7 +343,7 @@ class BasePanel(ScreenPanel):
             self.control['spoolman_box'].show()
             return
         remaining_weight = self._printer.active_spool["remaining_weight"]
-        self.labels['spoolman_weight'].set_label(f' {round(remaining_weight):.0f} g')
+        self.labels['spoolman_weight'].set_label(f'{round(remaining_weight):.0f} g')
         self.update_spoolman_alert_visuals(
             self.spoolman_low_limit > 0 and remaining_weight < self.spoolman_low_limit
         )

--- a/panels/base_panel.py
+++ b/panels/base_panel.py
@@ -7,7 +7,7 @@ import re
 import gi
 
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gio, GLib, Gtk, Pango, GdkPixbuf
+from gi.repository import GLib, Gtk, Pango, GdkPixbuf
 from jinja2 import Environment
 from datetime import datetime
 from math import log
@@ -115,10 +115,10 @@ class BasePanel(ScreenPanel):
 
         self.labels['spoolman_icon'] = Gtk.Image()
         self.labels['spoolman_weight'] = Gtk.Label()
-        self.control['spoolman_box'] = Gtk.Box()
+        self.control['spoolman_box'] = Gtk.Box(halign=Gtk.Align.END, spacing=1)
         self.control['spoolman_box'].set_no_show_all(True)
-        self.control['spoolman_box'].pack_start(self.labels['spoolman_icon'], False, False, 7)
-        self.control['spoolman_box'].pack_start(self.labels['spoolman_weight'], False, False, 0)
+        self.control['spoolman_box'].add(self.labels['spoolman_icon'])
+        self.control['spoolman_box'].add(self.labels['spoolman_weight'])
         self.labels['spoolman_icon'].show()
         self.labels['spoolman_weight'].show()
         self.load_spoolman_icons()
@@ -180,20 +180,6 @@ class BasePanel(ScreenPanel):
     def load_spoolman_icons(self):
         self.spoolman_icon_alert_pixbuf = self.get_spoolman_icon_pixbuf("981E1F", full_icon=True)
 
-    def get_spoolman_icon_size(self, svg):
-        match = re.search(r'viewBox="\s*[\d.]+\s+[\d.]+\s+([\d.]+)\s+([\d.]+)\s*"', svg)
-        if not match:
-            match = re.search(r'width="([\d.]+)".*height="([\d.]+)"', svg, re.DOTALL)
-        if not match:
-            return self.spoolman_icon_size, self.spoolman_icon_size
-        width = float(match.group(1))
-        height = float(match.group(2))
-        if width <= 0 or height <= 0:
-            return self.spoolman_icon_size, self.spoolman_icon_size
-        target_height = self.spoolman_icon_size
-        target_width = max(1, round(target_height * width / height))
-        return target_width, target_height
-
     def get_spoolman_icon_pixbuf(self, color, full_icon=False):
         klipperscreendir = pathlib.Path(__file__).parent.resolve().parent
         icon_path = os.path.join(klipperscreendir, "styles", self._screen.theme, "images", "spool.svg")
@@ -204,17 +190,11 @@ class BasePanel(ScreenPanel):
             svg = svg.replace("var(--filament-color)", f"#{color}")
             if full_icon:
                 svg = re.sub(r'fill:\s*(?!none)[^;"\']+', f'fill:#{color}', svg)
-            target_width, target_height = self.get_spoolman_icon_size(svg)
-            stream = Gio.MemoryInputStream.new_from_data(svg.encode(), None)
-            pixbuf = GdkPixbuf.Pixbuf.new_from_stream_at_scale(
-                stream,
-                target_width,
-                target_height,
-                True,
-                None,
-            )
-            stream.close_async(2)
-            return pixbuf
+            loader = GdkPixbuf.PixbufLoader()
+            loader.set_size(self.spoolman_icon_size, self.spoolman_icon_size)
+            loader.write(svg.encode())
+            loader.close()
+            return loader.get_pixbuf()
         except Exception as e:
             logging.error(f"Couldn't load spoolman icon: {e}")
             return self._gtk.PixbufFromIcon("spool", self.spoolman_icon_size, self.spoolman_icon_size)
@@ -359,7 +339,7 @@ class BasePanel(ScreenPanel):
                 or self._printer.active_spool["remaining_weight"] is None
         ):
             self.update_spoolman_alert_visuals(False)
-            self.labels['spoolman_weight'].set_label("?")
+            self.labels['spoolman_weight'].set_label(" ?")
             self.control['spoolman_box'].show()
             return
         remaining_weight = self._printer.active_spool["remaining_weight"]

--- a/panels/base_panel.py
+++ b/panels/base_panel.py
@@ -420,7 +420,8 @@ class BasePanel(ScreenPanel):
         if action == "notify_active_spool_set":
             spool_id = data.get("spool_id") if isinstance(data, dict) else None
             self.refresh_spoolman_weight(
-                self._printer is not None and self._printer.state not in {'disconnected', 'startup', 'shutdown', 'error'},
+                self._printer is not None
+                and self._printer.state not in {'disconnected', 'startup', 'shutdown', 'error'},
                 spool_id=spool_id
             )
             return

--- a/panels/base_panel.py
+++ b/panels/base_panel.py
@@ -330,15 +330,23 @@ class BasePanel(ScreenPanel):
     def update_spoolman_weight_label(self):
         if (
                 self._printer is None
-                or not self._printer.spoolman
                 or not self.show_spoolman_in_title
+        ):
+            self.stop_spoolman_blink()
+            self.update_spoolman_alert_visuals(False)
+            self.labels['spoolman_weight'].set_label("- g")
+            self.control['spoolman_box'].show()
+            return
+        if (
+                not self._printer.spoolman
                 or not self._printer.active_spool
                 or "remaining_weight" not in self._printer.active_spool
                 or self._printer.active_spool["remaining_weight"] is None
         ):
             self.stop_spoolman_blink()
             self.update_spoolman_alert_visuals(False)
-            self.control['spoolman_box'].hide()
+            self.labels['spoolman_weight'].set_label("- g")
+            self.control['spoolman_box'].show()
             return
         remaining_weight = self._printer.active_spool["remaining_weight"]
         self.labels['spoolman_weight'].set_label(f'{round(remaining_weight):.0f}g')
@@ -353,10 +361,19 @@ class BasePanel(ScreenPanel):
         self.control['spoolman_box'].show()
 
     def refresh_spoolman_weight(self, show=True, spool_id=None):
-        if self._printer is None or not self._printer.spoolman or not self.show_spoolman_in_title or not show:
+        if self._printer is None or not self.show_spoolman_in_title:
             self.stop_spoolman_blink()
             self.update_spoolman_alert_visuals(False)
             self.control['spoolman_box'].hide()
+            return
+        if not show:
+            self.stop_spoolman_blink()
+            self.update_spoolman_alert_visuals(False)
+            self.control['spoolman_box'].hide()
+            return
+        if not self._printer.spoolman:
+            self._printer.set_active_spool(checked=False)
+            self.update_spoolman_weight_label()
             return
         if spool_id is None and self._printer.active_spool_checked:
             self.update_spoolman_weight_label()

--- a/panels/base_panel.py
+++ b/panels/base_panel.py
@@ -35,7 +35,6 @@ class BasePanel(ScreenPanel):
         self.spoolman_blink_timeout = None
         self.spoolman_blink_state = False
         self.spoolman_icon_size = int(self._gtk.font_size * 1.1)
-        self.spoolman_icon_pixbuf = None
         self.spoolman_icon_alert_pixbuf = None
         self.current_extruder = None
         self.last_usage_report = datetime.now()
@@ -175,13 +174,10 @@ class BasePanel(ScreenPanel):
 
         self.battery_icons = self.load_battery_icons()
         self.battery_percentage()
-        self.load_spoolman_icons()
         self.update_spoolman_alert_visuals(self.spoolman_blink_state)
 
     def load_spoolman_icons(self):
-        self.spoolman_icon_pixbuf = self.get_spoolman_icon_pixbuf("FFFFFF")
         self.spoolman_icon_alert_pixbuf = self.get_spoolman_icon_pixbuf("981E1F")
-        self.labels['spoolman_icon'].set_from_pixbuf(self.spoolman_icon_pixbuf)
 
     def get_spoolman_icon_pixbuf(self, color):
         klipperscreendir = pathlib.Path(__file__).parent.resolve().parent
@@ -199,6 +195,20 @@ class BasePanel(ScreenPanel):
         except Exception as e:
             logging.error(f"Couldn't load spoolman icon: {e}")
             return self._gtk.PixbufFromIcon("spool", self.spoolman_icon_size, self.spoolman_icon_size)
+
+    def get_active_spoolman_color(self):
+        if (
+                self._printer is None
+                or not self._printer.active_spool
+                or "filament" not in self._printer.active_spool
+                or not self._printer.active_spool["filament"]
+        ):
+            return "FFFFFF"
+        filament = self._printer.active_spool["filament"]
+        color = filament.get("color_hex", "FFFFFF")
+        if not color:
+            return "FFFFFF"
+        return color.lstrip("#")
 
     def show_heaters(self, show=True):
         for child in self.control['temp_box'].get_children():
@@ -304,7 +314,9 @@ class BasePanel(ScreenPanel):
             self.labels['spoolman_icon'].set_from_pixbuf(self.spoolman_icon_alert_pixbuf)
             self.labels['spoolman_weight'].get_style_context().add_class("spoolman_low")
         else:
-            self.labels['spoolman_icon'].set_from_pixbuf(self.spoolman_icon_pixbuf)
+            self.labels['spoolman_icon'].set_from_pixbuf(
+                self.get_spoolman_icon_pixbuf(self.get_active_spoolman_color())
+            )
             self.labels['spoolman_weight'].get_style_context().remove_class("spoolman_low")
 
     def blink_spoolman_low(self):

--- a/panels/base_panel.py
+++ b/panels/base_panel.py
@@ -2,7 +2,6 @@
 import logging
 import os
 import pathlib
-import re
 
 import gi
 
@@ -121,7 +120,6 @@ class BasePanel(ScreenPanel):
         self.control['spoolman_box'].pack_start(self.labels['spoolman_weight'], False, False, 0)
         self.labels['spoolman_icon'].show()
         self.labels['spoolman_weight'].show()
-        self.load_spoolman_icons()
 
         self.titlebar = Gtk.Box(spacing=5, valign=Gtk.Align.CENTER)
         self.titlebar.get_style_context().add_class("title_bar")
@@ -177,24 +175,7 @@ class BasePanel(ScreenPanel):
         self.battery_percentage()
         self.update_spoolman_alert_visuals(False)
 
-    def load_spoolman_icons(self):
-        self.spoolman_icon_alert_pixbuf = self.get_spoolman_icon_pixbuf("981E1F", full_icon=True)
-
-    def get_spoolman_icon_size(self, svg):
-        match = re.search(r'viewBox="\s*[\d.]+\s+[\d.]+\s+([\d.]+)\s+([\d.]+)\s*"', svg)
-        if not match:
-            match = re.search(r'width="([\d.]+)".*height="([\d.]+)"', svg, re.DOTALL)
-        if not match:
-            return self.spoolman_icon_size, self.spoolman_icon_size
-        width = float(match.group(1))
-        height = float(match.group(2))
-        if width <= 0 or height <= 0:
-            return self.spoolman_icon_size, self.spoolman_icon_size
-        target_height = self.spoolman_icon_size
-        target_width = max(1, round(target_height * width / height))
-        return target_width, target_height
-
-    def get_spoolman_icon_pixbuf(self, color, full_icon=False):
+    def get_spoolman_icon_pixbuf(self, color):
         klipperscreendir = pathlib.Path(__file__).parent.resolve().parent
         icon_path = os.path.join(klipperscreendir, "styles", self._screen.theme, "images", "spool.svg")
         if not os.path.isfile(icon_path):
@@ -202,14 +183,11 @@ class BasePanel(ScreenPanel):
         try:
             svg = pathlib.Path(icon_path).read_text(encoding="utf-8")
             svg = svg.replace("var(--filament-color)", f"#{color}")
-            if full_icon:
-                svg = re.sub(r'fill:\s*(?!none)[^;"\']+', f'fill:#{color}', svg)
-            target_width, target_height = self.get_spoolman_icon_size(svg)
             stream = Gio.MemoryInputStream.new_from_data(svg.encode(), None)
             pixbuf = GdkPixbuf.Pixbuf.new_from_stream_at_scale(
                 stream,
-                target_width,
-                target_height,
+                -1,
+                self.spoolman_icon_size,
                 True,
                 None,
             )
@@ -220,21 +198,19 @@ class BasePanel(ScreenPanel):
             return self._gtk.PixbufFromIcon("spool", self.spoolman_icon_size, self.spoolman_icon_size)
 
     def get_active_spoolman_color(self):
+        default_color = "000000"
         if (
                 self._printer is None
                 or not self._printer.active_spool
                 or "filament" not in self._printer.active_spool
                 or not self._printer.active_spool["filament"]
         ):
-            return "000000"
+            return default_color
         filament = self._printer.active_spool["filament"]
-        color = filament.get("color_hex", "000000")
-        if not isinstance(color, str):
-            return "000000"
-        color = color.strip().lstrip("#")
-        if not color or not re.fullmatch(r"[0-9a-fA-F]{3}|[0-9a-fA-F]{6}", color):
-            return "000000"
-        return color
+        color = filament.get("color_hex")
+        if isinstance(color, str):
+            return color.strip().lstrip("#") or default_color
+        return default_color
 
     def show_heaters(self, show=True):
         for child in self.control['temp_box'].get_children():
@@ -335,13 +311,12 @@ class BasePanel(ScreenPanel):
         self.content.add(panel.content)
 
     def update_spoolman_alert_visuals(self, alert):
+        self.labels['spoolman_icon'].set_from_pixbuf(
+            self.get_spoolman_icon_pixbuf(self.get_active_spoolman_color())
+        )
         if alert:
-            self.labels['spoolman_icon'].set_from_pixbuf(self.spoolman_icon_alert_pixbuf)
             self.labels['spoolman_weight'].get_style_context().add_class("spoolman_low")
         else:
-            self.labels['spoolman_icon'].set_from_pixbuf(
-                self.get_spoolman_icon_pixbuf(self.get_active_spoolman_color())
-            )
             self.labels['spoolman_weight'].get_style_context().remove_class("spoolman_low")
 
     def update_spoolman_weight_label(self):

--- a/panels/base_panel.py
+++ b/panels/base_panel.py
@@ -330,8 +330,7 @@ class BasePanel(ScreenPanel):
                 or not self.show_spoolman_in_title
         ):
             self.update_spoolman_alert_visuals(False)
-            self.labels['spoolman_weight'].set_label("- g")
-            self.control['spoolman_box'].show()
+            self.control['spoolman_box'].hide()
             return
         if (
                 not self._printer.spoolman
@@ -340,11 +339,11 @@ class BasePanel(ScreenPanel):
                 or self._printer.active_spool["remaining_weight"] is None
         ):
             self.update_spoolman_alert_visuals(False)
-            self.labels['spoolman_weight'].set_label("- g")
+            self.labels['spoolman_weight'].set_label(" ?")
             self.control['spoolman_box'].show()
             return
         remaining_weight = self._printer.active_spool["remaining_weight"]
-        self.labels['spoolman_weight'].set_label(f'{round(remaining_weight):.0f}g')
+        self.labels['spoolman_weight'].set_label(f' {round(remaining_weight):.0f} g')
         self.update_spoolman_alert_visuals(
             self.spoolman_low_limit > 0 and remaining_weight < self.spoolman_low_limit
         )

--- a/panels/base_panel.py
+++ b/panels/base_panel.py
@@ -127,7 +127,6 @@ class BasePanel(ScreenPanel):
         self.titlebar.get_style_context().add_class("title_bar")
         self.titlebar.add(self.control['temp_box'])
         self.titlebar.add(self.titlelbl)
-        self.titlebar.add(self.control['spoolman_box'])
         self.titlebar.add(self.control['time_box'])
         self.titlebar.add(self.control['battery_box'])
         self.set_title(title)
@@ -204,6 +203,7 @@ class BasePanel(ScreenPanel):
     def show_heaters(self, show=True):
         for child in self.control['temp_box'].get_children():
             self.control['temp_box'].remove(child)
+        self.control['spoolman_box'].hide()
         if self._printer is None or not show:
             return
         try:
@@ -247,6 +247,10 @@ class BasePanel(ScreenPanel):
                         self.control['temp_box'].add(self.labels[f"{device}_box"])
                         n += 1
                         break
+
+            if self.show_spoolman_in_title and self._printer.spoolman and n < nlimit + 1:
+                self.control['temp_box'].add(self.control['spoolman_box'])
+                n += 1
 
             self.control['temp_box'].show_all()
         except Exception as e:

--- a/panels/base_panel.py
+++ b/panels/base_panel.py
@@ -35,8 +35,6 @@ class BasePanel(ScreenPanel):
         self.titlebar_name_type = None
         self.show_spoolman_in_title = False
         self.spoolman_low_limit = 0
-        self.spoolman_blink_timeout = None
-        self.spoolman_blink_state = False
         self.spoolman_icon_size = int(self._gtk.font_size * 1.1)
         self.spoolman_icon_alert_pixbuf = None
         self.current_extruder = None
@@ -177,7 +175,7 @@ class BasePanel(ScreenPanel):
 
         self.battery_icons = self.load_battery_icons()
         self.battery_percentage()
-        self.update_spoolman_alert_visuals(self.spoolman_blink_state)
+        self.update_spoolman_alert_visuals(False)
 
     def load_spoolman_icons(self):
         self.spoolman_icon_alert_pixbuf = self.get_spoolman_icon_pixbuf("981E1F", full_icon=True)
@@ -256,13 +254,17 @@ class BasePanel(ScreenPanel):
                     self.control['temp_box'].add(self.labels[f"{device}_box"])
                     n += 1
             for item in self.titlebar_items:
+                if n >= nlimit:
+                    break
                 if item == "spool" and self._printer.spoolman:
                     self.control['temp_box'].add(self.control['spoolman_box'])
+                    n += 1
                     continue
                 for device in devices:
                     name = device.split()[1] if len(device.split()) > 1 else device
                     if name == item and self.labels[f"{device}_box"].get_parent() is None:
                         self.control['temp_box'].add(self.labels[f"{device}_box"])
+                        n += 1
                         break
 
             self.control['temp_box'].show_all()
@@ -311,12 +313,6 @@ class BasePanel(ScreenPanel):
         self.set_title(panel.title)
         self.content.add(panel.content)
 
-    def stop_spoolman_blink(self):
-        if self.spoolman_blink_timeout is not None:
-            GLib.source_remove(self.spoolman_blink_timeout)
-            self.spoolman_blink_timeout = None
-        self.spoolman_blink_state = False
-
     def update_spoolman_alert_visuals(self, alert):
         if alert:
             self.labels['spoolman_icon'].set_from_pixbuf(self.spoolman_icon_alert_pixbuf)
@@ -327,17 +323,11 @@ class BasePanel(ScreenPanel):
             )
             self.labels['spoolman_weight'].get_style_context().remove_class("spoolman_low")
 
-    def blink_spoolman_low(self):
-        self.spoolman_blink_state = not self.spoolman_blink_state
-        self.update_spoolman_alert_visuals(self.spoolman_blink_state)
-        return True
-
     def update_spoolman_weight_label(self):
         if (
                 self._printer is None
                 or not self.show_spoolman_in_title
         ):
-            self.stop_spoolman_blink()
             self.update_spoolman_alert_visuals(False)
             self.labels['spoolman_weight'].set_label("- g")
             self.control['spoolman_box'].show()
@@ -348,31 +338,23 @@ class BasePanel(ScreenPanel):
                 or "remaining_weight" not in self._printer.active_spool
                 or self._printer.active_spool["remaining_weight"] is None
         ):
-            self.stop_spoolman_blink()
             self.update_spoolman_alert_visuals(False)
             self.labels['spoolman_weight'].set_label("- g")
             self.control['spoolman_box'].show()
             return
         remaining_weight = self._printer.active_spool["remaining_weight"]
         self.labels['spoolman_weight'].set_label(f'{round(remaining_weight):.0f}g')
-        if self.spoolman_low_limit > 0 and remaining_weight < self.spoolman_low_limit:
-            if self.spoolman_blink_timeout is None:
-                self.spoolman_blink_state = True
-                self.update_spoolman_alert_visuals(True)
-                self.spoolman_blink_timeout = GLib.timeout_add(700, self.blink_spoolman_low)
-        else:
-            self.stop_spoolman_blink()
-            self.update_spoolman_alert_visuals(False)
+        self.update_spoolman_alert_visuals(
+            self.spoolman_low_limit > 0 and remaining_weight < self.spoolman_low_limit
+        )
         self.control['spoolman_box'].show()
 
     def refresh_spoolman_weight(self, show=True, spool_id=SPOOL_ID_UNSET):
         if self._printer is None or not self.show_spoolman_in_title:
-            self.stop_spoolman_blink()
             self.update_spoolman_alert_visuals(False)
             self.control['spoolman_box'].hide()
             return
         if not show:
-            self.stop_spoolman_blink()
             self.update_spoolman_alert_visuals(False)
             self.control['spoolman_box'].hide()
             return

--- a/panels/base_panel.py
+++ b/panels/base_panel.py
@@ -206,12 +206,15 @@ class BasePanel(ScreenPanel):
                 or "filament" not in self._printer.active_spool
                 or not self._printer.active_spool["filament"]
         ):
-            return "FFFFFF"
+            return "000000"
         filament = self._printer.active_spool["filament"]
-        color = filament.get("color_hex", "FFFFFF")
-        if not color:
-            return "FFFFFF"
-        return color.lstrip("#")
+        color = filament.get("color_hex", "000000")
+        if not isinstance(color, str):
+            return "000000"
+        color = color.strip().lstrip("#")
+        if not color or not re.fullmatch(r"[0-9a-fA-F]{3}|[0-9a-fA-F]{6}", color):
+            return "000000"
+        return color
 
     def show_heaters(self, show=True):
         for child in self.control['temp_box'].get_children():

--- a/screen.py
+++ b/screen.py
@@ -1108,6 +1108,7 @@ class KlipperScreen(Gtk.Window):
                 self.printer.configure_cameras(cameras['webcams'])
         if "spoolman" in self.server_info["components"]:
             self.printer.enable_spoolman()
+            self.base_panel.refresh_spoolman_weight()
 
     def init_klipper(self):
         if self.reinit_count > self.max_retries or 'printer_select' in self._cur_panels:

--- a/styles/base.css
+++ b/styles/base.css
@@ -290,6 +290,10 @@ trough {
     min-height: 2em;
 }
 
+.spoolman_low {
+    color: @error;
+}
+
 .content {
     margin: 0 .1em;
 }

--- a/styles/base.css
+++ b/styles/base.css
@@ -291,7 +291,7 @@ trough {
 }
 
 .spoolman_low {
-    color: @error;
+    color: @warning;
 }
 
 .content {


### PR DESCRIPTION
This PR adds Spoolman integration to the KlipperScreen title bar as a configurable titlebar_items entry.

When spoolman is included in titlebar_items, KlipperScreen shows the active spool remaining weight in the title bar using a spool icon and compact weight label. The icon uses the current filament color from Spoolman, matching the existing Spoolman panel.

A new optional printer setting, spoolman_low_limit, was also added. When the remaining spool weight drops below this configured value, both the weight text and the full spool icon blink red.

If spool data is unavailable, no spool is selected, or Spoolman cannot provide the active spool state, the title bar shows a fallback placeholder of - g.

**Changes**

- Added spoolman as a supported titlebar_items entry
- Added spoolman_low_limit as a printer configuration option
- Display active spool remaining weight in the title bar
- Use the active filament color for the spool icon
- Blink the full spool icon and weight red below the configured low limit
- Show - g when spool data is unavailable or no active spool is selected
- Updated configuration documentation

**Configuration**

Example:

```
[printer MyPrinter]
titlebar_items: chamber, spool
spool_low_limit: 20
```
**Options:**
`spoolman in titlebar_items`
Enables the Spoolman title bar item
`spoolman_low_limit`
Optional low-weight threshold in grams
When remaining weight is below this value, the spool icon and weight blink red

**Behavior**

- If Moonraker Spoolman integration is available and an active spool is selected, the title bar shows the remaining spool weight
- If the active spool has a filament color, that color is used for the spool icon
- If remaining weight is below spoolman_low_limit, the full icon and weight blink red
- If no spool is selected, spool data is unavailable, or Spoolman cannot provide the data, the title bar shows - g

**Testing**

- Moonraker Spoolman integration enabled
- Active spool selected
- titlebar_items: chamber, spoolman
- Low limit behavior with red blinking alert
- Filament color reflected in the title bar spool icon
- Placeholder behavior when the active spool is cleared
<img width="800" height="480" alt="screenshot-spool_000" src="https://github.com/user-attachments/assets/7f946aff-9e82-484c-a5e0-73d4b8667ed6" />
<img width="800" height="480" alt="screenshot-spool_001" src="https://github.com/user-attachments/assets/90f51dab-7442-4bbc-aec0-47b0b5106ed8" />
