### PR TITLE
Refresh spool titlebar during prints - fix

### DIFF
--- a/panels/base_panel.py
+++ b/panels/base_panel.py
@@ -296,7 +296,7 @@ class BasePanel(ScreenPanel):
         if self.battery_update is None:
             self.battery_update = GLib.timeout_add_seconds(60, self.battery_percentage)
         if self.spoolman_update is None:
-            self.spoolman_update = GLib.timeout_add_seconds(10, self.update_spoolman_during_print)
+            self.spoolman_update = GLib.timeout_add_seconds(60, self.update_spoolman_during_print)
 
     def add_content(self, panel):
         printing = self._printer and self._printer.state in {"printing", "paused"}

--- a/panels/base_panel.py
+++ b/panels/base_panel.py
@@ -30,12 +30,14 @@ class BasePanel(ScreenPanel):
         self.time_format = self._config.get_main_config().getboolean("24htime", True)
         self.time_update = None
         self.battery_update = None
+        self.spoolman_update = None
         self.titlebar_items = []
         self.titlebar_name_type = None
         self.show_spoolman_in_title = False
         self.spoolman_low_limit = 20
         self.spoolman_icon_size = self._gtk.img_scale * self.bts * .9
         self.spoolman_icon_alert_pixbuf = None
+        self.spoolman_printing = False
         self.current_extruder = None
         self.last_usage_report = datetime.now()
         self.usage_report = 0
@@ -293,6 +295,8 @@ class BasePanel(ScreenPanel):
             self.time_update = GLib.timeout_add_seconds(1, self.update_time)
         if self.battery_update is None:
             self.battery_update = GLib.timeout_add_seconds(60, self.battery_percentage)
+        if self.spoolman_update is None:
+            self.spoolman_update = GLib.timeout_add_seconds(10, self.update_spoolman_during_print)
 
     def add_content(self, panel):
         printing = self._printer and self._printer.state in {"printing", "paused"}
@@ -342,7 +346,7 @@ class BasePanel(ScreenPanel):
         self.update_spoolman_alert_visuals(remaining_weight < self.spoolman_low_limit)
         self.control['spoolman_box'].show()
 
-    def refresh_spoolman_weight(self, show=True, spool_id=SPOOL_ID_UNSET):
+    def refresh_spoolman_weight(self, show=True, spool_id=SPOOL_ID_UNSET, force=False):
         if self._printer is None or not self.show_spoolman_in_title:
             self.update_spoolman_alert_visuals(False)
             self.control['spoolman_box'].hide()
@@ -355,7 +359,7 @@ class BasePanel(ScreenPanel):
             self._printer.set_active_spool(checked=False)
             self.update_spoolman_weight_label()
             return
-        if spool_id is SPOOL_ID_UNSET and self._printer.active_spool_checked:
+        if not force and spool_id is SPOOL_ID_UNSET and self._printer.active_spool_checked:
             self.update_spoolman_weight_label()
             return
         if spool_id is SPOOL_ID_UNSET:
@@ -386,6 +390,23 @@ class BasePanel(ScreenPanel):
             return
         self._printer.set_active_spool(spool_id=spool_id, spool=spool["result"])
         self.update_spoolman_weight_label()
+
+    def update_spoolman_during_print(self):
+        if self._printer is None:
+            self.spoolman_printing = False
+            return True
+
+        connected = self._printer.state not in {'disconnected', 'startup', 'shutdown', 'error'}
+        printer_select = 'printer_select' not in self._screen._cur_panels
+        is_printing = self._printer.state in {"printing", "paused"}
+
+        if is_printing:
+            self.refresh_spoolman_weight(connected and printer_select, force=True)
+        elif self.spoolman_printing:
+            self.refresh_spoolman_weight(connected and printer_select, force=True)
+
+        self.spoolman_printing = is_printing
+        return True
 
     def back(self, widget=None):
         if self.current_panel is None:
@@ -455,6 +476,17 @@ class BasePanel(ScreenPanel):
             return
         if action != "notify_status_update" or self._screen.printer is None:
             return
+        is_printing = self._printer.state in {"printing", "paused"}
+        if is_printing != self.spoolman_printing:
+            connected = (
+                self._printer is not None
+                and self._printer.state not in {'disconnected', 'startup', 'shutdown', 'error'}
+            )
+            self.refresh_spoolman_weight(
+                connected and 'printer_select' not in self._screen._cur_panels,
+                force=True
+            )
+            self.spoolman_printing = is_printing
         devices = self._printer.get_temp_devices()
         if not devices:
             return


### PR DESCRIPTION
### This follow-up PR keeps the merged spool titlebar feature in sync during and after prints.

### What it changes:

- refreshes the active spool data every 10 seconds while printing or paused
- performs one final refresh after leaving the printing state
- forces a real reload from Moonraker/Spoolman instead of reusing cached spool data

### Why this is needed:

- before this change, the titlebar spool weight was only refreshed when the panel was opened or when the active spool changed during a print, the remaining spool weight could stay stale and would not update automatically
- after print completion, the displayed value could also remain outdated until another spool event happened

This keeps the titlebar spool weight current during the print and ensures it is refreshed once more when the print finishes.