### PR TITLE
Fix spoolman refresh timer handling

### DIFF
--- a/panels/base_panel.py
+++ b/panels/base_panel.py
@@ -389,7 +389,7 @@ class BasePanel(ScreenPanel):
         printing = self._printer.state in {"printing", "paused"}
         printer_select = 'printer_select' in self._screen._cur_panels
         if printer_select or not printing:
-            return False
+            return True
         self.refresh_spoolman_weight(force=True)
         return True
 

--- a/screen.py
+++ b/screen.py
@@ -779,7 +779,7 @@ class KlipperScreen(Gtk.Window):
     def state_printing(self):
         self.show_panel("job_status", remove_all=True)
         if self.spoolman:
-            self.base_panel.set_spoolman_refresh(True)
+            self.base_panel.set_spoolman_refresh()
 
     def state_ready(self, wait=True):
         # Do not return to main menu if completing a job, timeouts/user input will return


### PR DESCRIPTION
**Changes:**

- fix the set_spoolman_refresh() call signature mismatch
- keep the Spoolman refresh timer alive when not printing or while printer_select is open