### PR TITLE
Fix double tap resume

### DIFF
--- a/panels/job_status.py
+++ b/panels/job_status.py
@@ -421,8 +421,14 @@ class Panel(ScreenPanel):
 
     def resume(self, widget):
         self.disable_button("pause", "resume")
+        GLib.timeout_add_seconds(5, self._re_enable_resume_if_paused)
         self._screen._ws.klippy.print_resume()
         self._screen.show_all()
+
+    def _re_enable_resume_if_paused(self):
+        if self.state == "paused":
+            self.enable_button("resume")
+        return False
 
     def pause(self, widget):
         self.disable_button("pause", "resume")

--- a/panels/job_status.py
+++ b/panels/job_status.py
@@ -420,7 +420,6 @@ class Panel(ScreenPanel):
             logging.info(f"Could not restart {self.filename}")
 
     def resume(self, widget):
-        self.disable_button("pause", "resume")
         self._screen._send_action(widget, "printer.print.resume", {})
         self._screen.show_all()
 

--- a/panels/job_status.py
+++ b/panels/job_status.py
@@ -420,6 +420,7 @@ class Panel(ScreenPanel):
             logging.info(f"Could not restart {self.filename}")
 
     def resume(self, widget):
+        self.disable_button("pause", "resume")
         self._screen._ws.klippy.print_resume()
         self._screen.show_all()
 

--- a/panels/job_status.py
+++ b/panels/job_status.py
@@ -421,18 +421,12 @@ class Panel(ScreenPanel):
 
     def resume(self, widget):
         self.disable_button("pause", "resume")
-        GLib.timeout_add_seconds(5, self._re_enable_resume_if_paused)
-        self._screen._ws.klippy.print_resume()
+        self._screen._send_action(widget, "printer.print.resume", {})
         self._screen.show_all()
-
-    def _re_enable_resume_if_paused(self):
-        if self.state == "paused":
-            self.enable_button("resume")
-        return False
 
     def pause(self, widget):
         self.disable_button("pause", "resume")
-        self._screen._ws.klippy.print_pause()
+        self._screen._send_action(widget, "printer.print.pause", {})
         self._screen.show_all()
 
     def cancel(self, widget):


### PR DESCRIPTION
Currently the resume button isn't deactivated after it is pressed, this means you can accidentally press it again while resuming, which can cause a move out of range and abort the print. This change disables the button after it is pressed in the same way pause is.