### PR TITLE
Fix: temperature chart closing immediately

### DIFF
--- a/ks_includes/widgets/heatergraph.py
+++ b/ks_includes/widgets/heatergraph.py
@@ -22,9 +22,10 @@ class HeaterGraph(Gtk.DrawingArea):
         self.connect('draw', self.draw_graph)
         self.add_events(Gdk.EventMask.TOUCH_MASK)
         self.add_events(Gdk.EventMask.BUTTON_PRESS_MASK)
+        self.add_events(Gdk.EventMask.BUTTON_RELEASE_MASK)
         self.connect('button_press_event', screen.screensaver.reset_timeout)
         self.connect('button_press_event', screen.lock_screen.reset_timeout)
-        self.connect('button_press_event', self.event_cb)
+        self.connect('button_release_event', self.event_cb)
         self.font_size = round(font_size * 0.75)
         self.fullscreen = fullscreen
         if fullscreen:


### PR DESCRIPTION
The temperature chart opens on press and closes on release, which causes it to immediately close after being opened.

With this fix, it now opens on release, like any other button, so now it stays open.