### PR TITLE
feat: add support for hiding specific sensors via configuration

### DIFF
--- a/ks_includes/config.py
+++ b/ks_includes/config.py
@@ -190,7 +190,7 @@ class KlipperScreenConfig:
                 )
                 strs = (
                     'moonraker_api_key', 'moonraker_host', 'moonraker_path', 'titlebar_name_type',
-                    'screw_positions', 'power_devices', 'titlebar_items', 'z_babystep_values',
+                    'screw_positions', 'power_devices', 'titlebar_items', 'hidden_sensors', 'z_babystep_values',
                     'extrude_distances', 'extrude_speeds', 'move_distances', 'zcalibrate_custom_commands'
                 )
                 numbers = (

--- a/panels/base_panel.py
+++ b/panels/base_panel.py
@@ -543,9 +543,16 @@ class BasePanel(ScreenPanel):
                 logging.info(f"Titlebar name type: {self.titlebar_name_type} items: {self.titlebar_items}")
             else:
                 self.titlebar_items = []
+            hidden_sensors = self.ks_printer_cfg.get("hidden_sensors", None)
+            if hidden_sensors is not None:
+                ScreenPanel.hidden_sensors = [str(i.strip()).lower() for i in hidden_sensors.split(',')]
+                logging.info(f"Hidden sensors: {self.hidden_sensors}")
+            else:
+                ScreenPanel.hidden_sensors = []
             self.spoolman_low_limit = self.ks_printer_cfg.getfloat("spool_low_limit", fallback=20)
         else:
             self.titlebar_items = []
+            ScreenPanel.hidden_sensors = []
             self.spoolman_low_limit = 20
 
     def show_update_dialog(self):

--- a/panels/main_menu.py
+++ b/panels/main_menu.py
@@ -93,6 +93,8 @@ class Panel(MenuPanel):
         # Support for hiding devices by name
         if devname.startswith("_"):
             return False
+        if devname.lower() in self.hidden_sensors:
+            return False
 
         if device.startswith("extruder"):
             if self._printer.extrudercount > 1:

--- a/panels/temperature.py
+++ b/panels/temperature.py
@@ -343,6 +343,8 @@ class Panel(ScreenPanel):
         # Support for hiding devices by name
         if devname.startswith("_"):
             return False
+        if devname.lower() in self.hidden_sensors:
+            return False
 
         if device.startswith("extruder"):
             if self._printer.extrudercount > 1:


### PR DESCRIPTION
### Summary
This PR introduces a new configuration option, `hidden_sensors`, allowing users to explicitly hide specific sensors or devices from the UI. Previously, hiding was only supported by prefixing a device name with an underscore (`_`). This change enables more flexibility by allowing a comma-separated list of sensor names to be defined in the printer configuration.

### Changes
*   **Configuration Validation**: Added `hidden_sensors` to the validated strings list in `ks_includes/config.py`.
*   **Config Parsing**: Updated `base_panel.py` to parse the `hidden_sensors` string into a list of lowercase, stripped strings stored in `ScreenPanel`.
*   **UI Filtering**: Updated the `add_device` logic in both `main_menu.py` and `temperature.py` to check against the `hidden_sensors` list. If a device name (case-insensitive) matches a name in the list, it will not be displayed.

### Configuration Example
In your configuration file, you can now use:
```ini
[printer Printer]
hidden_sensors = Octopus_Pro_H723_V1.1,raspberry_pi
```