### PR TITLE
feat: support dynamic registration of temperature sensors

### DIFF
--- a/ks_includes/printer.py
+++ b/ks_includes/printer.py
@@ -101,6 +101,18 @@ class Printer:
         self.log_counts(printer_info)
         self.process_update(data)
 
+    def register_dynamic_sensors(self, objects):
+        for obj in objects:
+            if obj.startswith("temperature_sensor "):
+                name = obj.split(" ", 1)[1]
+                if name.startswith("_"):
+                    continue
+                if obj not in self.config:
+                    logging.info(f"Registering dynamic sensor: {obj}")
+                    self.config[obj] = {}
+                    self.data[obj] = {"temperature": 0}
+                    self.tempdevcount += 1
+
     def log_counts(self, printer_info):
         logging.info(f"Klipper version: {printer_info['software_version']}")
         logging.info(f"# Extruders: {self.extrudercount}")

--- a/panels/main_menu.py
+++ b/panels/main_menu.py
@@ -271,6 +271,8 @@ class Panel(MenuPanel):
             return
         for x in self._printer.get_temp_devices():
             if x in data:
+                if x not in self.devices:
+                    self.add_device(x)
                 self.update_temp(
                     x,
                     self._printer.get_stat(x, "temperature"),

--- a/panels/temperature.py
+++ b/panels/temperature.py
@@ -606,6 +606,8 @@ class Panel(ScreenPanel):
             return
         for x in self._printer.get_temp_devices():
             if x in data:
+                if x not in self.devices:
+                    self.add_device(x)
                 self.update_temp(
                     x,
                     self._printer.get_stat(x, "temperature"),

--- a/screen.py
+++ b/screen.py
@@ -1157,6 +1157,9 @@ class KlipperScreen(Gtk.Window):
             self._init_printer("Error getting printer configuration")
             return False
         self.printer.reinit(printer_info, config['status'])
+        objects = self.apiclient.send_request("printer/objects/list")
+        if objects and 'objects' in objects:
+            self.printer.register_dynamic_sensors(objects['objects'])
         self.printer.available_commands = self.apiclient.get_gcode_help()
         info = self.apiclient.send_request("machine/system_info")
         if info and 'system_info' in info:


### PR DESCRIPTION
### Summary
Some Klipper plugins (e.g., [Beacon](https://github.com/beacon3d/beacon_klipper)) create temperature_sensor objects dynamically at runtime rather than through printer.cfg. These sensors don't appear in Klipper's configfile API response, so KlipperScreen never registers them, never subscribes to their updates, and they're completely missing from the UI, even though they're visible in Mainsail/Fluidd.

This PR fixes that by querying Klipper's object list during initialization to discover and register any temperature sensors that aren't in the config.

<img width="1215" height="911" alt="image" src="https://github.com/user-attachments/assets/55d774c9-7f28-4d34-aec9-fb70f2be7fa8" />


### Changes
*   **Dynamic Sensor Registration**: Added `register_dynamic_sensors` to `ks_includes/printer.py`. This method scans the Klipper object list for `temperature_sensor` entries, filters out hidden ones (starting with `_`), and initializes them in the internal data structure if they are missing.
*   **Startup Discovery**: Updated `screen.py` to fetch the full list of printer objects from the Moonraker API during Klipper initialization and pass them to the registration logic.
*   **Reactive UI Updates**: Updated `process_update` in both `main_menu.py` and `temperature.py` to check if a device exists in the current panel. If a sensor update is received for a known printer device that hasn't been added to the UI yet, it is now dynamically added to the panel.

### Technical Details
- Increments `tempdevcount` for each newly discovered sensor to ensure accurate device counts.
- Maintains existing naming conventions (respecting the `_` prefix for hidden sensors).
- Ensures that sensors appearing mid-session (via `process_update`) trigger the `add_device` UI logic to prevent missing entries on the display panels.