### PR TITLE
install: print system is going to reboot

### DIFF
--- a/scripts/KlipperScreen-install.sh
+++ b/scripts/KlipperScreen-install.sh
@@ -312,6 +312,7 @@ EOF
         sudo systemctl enable NetworkManager
         sudo systemctl -q --no-block start NetworkManager
         sync
+        echo "Rebooting system..."
         systemctl reboot
     fi
 }


### PR DESCRIPTION
It's always a bit surprising to see the klipperscreen install end with:

```
Summary:
  Upgrading: 0, Installing: 0, Removing: 0, Not Upgrading: 0
Starting service...
Connection to myprinter.local closed by remote host.
Connection to myprinter.local closed.

```

and suddenly close ssh and reboot the system. Added a message to let the user know what's going on.