### PR TITLE
Add spool titlebar shortcut

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -98,6 +98,13 @@ moonraker_port: 7125
 # When the active spool drops below this value, the spool icon and weight turn red.
 # spool_low_limit: 20
 
+# Defines what the spool item in the title bar opens when tapped.
+# spool = active spool editor, falls back to the Spoolman list when no spool is active
+# spoolman = Spoolman list
+# If not set, or if an invalid value is provided, the title-bar spool item
+# remains informational only and does not open a panel.
+# spool_shortcut: spoolman
+
 # Z probe calibrate position
 # By default it tries to guess the correct location
 # it will try using zero reference position, safe_z, mesh midddle, middle of axis length, etc

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -98,13 +98,6 @@ moonraker_port: 7125
 # When the active spool drops below this value, the spool icon and weight turn red.
 # spool_low_limit: 20
 
-# Defines what the spool item in the title bar opens when tapped.
-# spool = active spool editor, falls back to the Spoolman list when no spool is active
-# spoolman = Spoolman list
-# If not set, or if an invalid value is provided, the title-bar spool item
-# remains informational only and does not open a panel.
-# spool_shortcut: spoolman
-
 # Z probe calibrate position
 # By default it tries to guess the correct location
 # it will try using zero reference position, safe_z, mesh midddle, middle of axis length, etc

--- a/ks_includes/config.py
+++ b/ks_includes/config.py
@@ -248,6 +248,7 @@ class KlipperScreenConfig:
                     "extrude_speeds",
                     "move_distances",
                     "zcalibrate_custom_commands",
+                    "spool_shortcut",
                 )
                 numbers = (
                     "moonraker_port",

--- a/ks_includes/config.py
+++ b/ks_includes/config.py
@@ -248,7 +248,6 @@ class KlipperScreenConfig:
                     "extrude_speeds",
                     "move_distances",
                     "zcalibrate_custom_commands",
-                    "spool_shortcut",
                 )
                 numbers = (
                     "moonraker_port",
@@ -329,7 +328,6 @@ class KlipperScreenConfig:
         return "".join(f"{error}\n\n" for error in self.errors)
 
     def _create_configurable_options(self, screen):
-
         self.configurable_options = [
             {
                 "theme": {

--- a/panels/base_panel.py
+++ b/panels/base_panel.py
@@ -304,6 +304,7 @@ class BasePanel(ScreenPanel):
             return
 
         from panels.spoolman import SpoolmanSpool
+
         if SpoolmanSpool.theme_path != self._screen.theme:
             SpoolmanSpool.theme_path = self._screen.theme
             SpoolmanSpool._spool_icon = None

--- a/panels/base_panel.py
+++ b/panels/base_panel.py
@@ -34,7 +34,6 @@ class BasePanel(ScreenPanel):
         self.spoolman_update = None
         self.titlebar_items = []
         self.titlebar_name_type = None
-        self.spool_shortcut = None
         self.spoolman_low_limit = 20
         self.spoolman_current_color = None
         self.current_extruder = None
@@ -118,14 +117,12 @@ class BasePanel(ScreenPanel):
         self.labels["spoolman_icon"] = Gtk.Image()
         self.labels["spoolman_icon"].set_from_pixbuf(self.get_spoolman_icon_pixbuf())
         self.labels["spoolman_weight"] = Gtk.Label(label="?")
-        self.control["spoolman_content"] = Gtk.Box()
-        self.control["spoolman_box"] = Gtk.Button()
-        self.control["spoolman_box"].set_relief(Gtk.ReliefStyle.NONE)
-        self.control["spoolman_box"].set_can_focus(False)
-        self.control["spoolman_box"].connect("clicked", self.open_spool_shortcut)
-        self.control["spoolman_content"].pack_start(self.labels["spoolman_icon"], False, False, 7)
-        self.control["spoolman_content"].pack_start(self.labels["spoolman_weight"], False, False, 0)
-        self.control["spoolman_box"].add(self.control["spoolman_content"])
+        spoolman_box = Gtk.Box()
+        spoolman_box.pack_start(self.labels["spoolman_icon"], False, False, 7)
+        spoolman_box.pack_start(self.labels["spoolman_weight"], False, False, 0)
+        self.control["spoolman_box"] = Gtk.EventBox()
+        self.control["spoolman_box"].add(spoolman_box)
+        self.control["spoolman_box"].connect("button-press-event", self.open_spool_panel)
 
         self.titlebar = Gtk.Box(spacing=5, valign=Gtk.Align.CENTER)
         self.titlebar.get_style_context().add_class("title_bar")
@@ -288,28 +285,9 @@ class BasePanel(ScreenPanel):
         self.set_spoolman_refresh()
         self.fetch_spoolman()
 
-    def open_spool_shortcut(self, widget=None):
-        if self.spool_shortcut == "spoolman":
-            self._screen.show_panel("spoolman")
-            return
-        if self.spool_shortcut != "spool":
-            return
-        spool_data = None if self._printer is None else self._printer.active_spool
-        if spool_data is None:
-            active_spool_id = self._screen.spoolman_api.get_active_spool_id()
-            if active_spool_id:
-                spool_data = self._screen.spoolman_api.get_spool_details(active_spool_id)
-        if spool_data is None:
-            self._screen.show_panel("spoolman")
-            return
-
-        from panels.spoolman import SpoolmanSpool
-
-        if SpoolmanSpool.theme_path != self._screen.theme:
-            SpoolmanSpool.theme_path = self._screen.theme
-            SpoolmanSpool._spool_icon = None
-        spool = SpoolmanSpool(**spool_data)
-        self._screen.show_panel("spool_editor", extra=spool)
+    def open_spool_panel(self, widget=None, event=None):
+        self._screen.show_panel("spoolman")
+        return True
 
     def get_icon(self, device, img_size):
         if device.startswith("extruder"):
@@ -605,17 +583,10 @@ class BasePanel(ScreenPanel):
                 logging.info(f"Hidden sensors: {self.hidden_sensors}")
             else:
                 ScreenPanel.hidden_sensors = []
-            raw_spool_shortcut = self.ks_printer_cfg.get("spool_shortcut", fallback=None)
-            if isinstance(raw_spool_shortcut, str):
-                raw_spool_shortcut = raw_spool_shortcut.strip().lower()
-            self.spool_shortcut = (
-                raw_spool_shortcut if raw_spool_shortcut in {"spool", "spoolman"} else None
-            )
             self.spoolman_low_limit = self.ks_printer_cfg.getfloat("spool_low_limit", fallback=20)
         else:
             self.titlebar_items = []
             ScreenPanel.hidden_sensors = []
-            self.spool_shortcut = None
             self.spoolman_low_limit = 20
 
     def show_update_dialog(self):

--- a/panels/base_panel.py
+++ b/panels/base_panel.py
@@ -34,6 +34,7 @@ class BasePanel(ScreenPanel):
         self.spoolman_update = None
         self.titlebar_items = []
         self.titlebar_name_type = None
+        self.spool_shortcut = None
         self.spoolman_low_limit = 20
         self.spoolman_current_color = None
         self.current_extruder = None
@@ -117,9 +118,14 @@ class BasePanel(ScreenPanel):
         self.labels["spoolman_icon"] = Gtk.Image()
         self.labels["spoolman_icon"].set_from_pixbuf(self.get_spoolman_icon_pixbuf())
         self.labels["spoolman_weight"] = Gtk.Label(label="?")
-        self.control["spoolman_box"] = Gtk.Box()
-        self.control["spoolman_box"].pack_start(self.labels["spoolman_icon"], False, False, 7)
-        self.control["spoolman_box"].pack_start(self.labels["spoolman_weight"], False, False, 0)
+        self.control["spoolman_content"] = Gtk.Box()
+        self.control["spoolman_box"] = Gtk.Button()
+        self.control["spoolman_box"].set_relief(Gtk.ReliefStyle.NONE)
+        self.control["spoolman_box"].set_can_focus(False)
+        self.control["spoolman_box"].connect("clicked", self.open_spool_shortcut)
+        self.control["spoolman_content"].pack_start(self.labels["spoolman_icon"], False, False, 7)
+        self.control["spoolman_content"].pack_start(self.labels["spoolman_weight"], False, False, 0)
+        self.control["spoolman_box"].add(self.control["spoolman_content"])
 
         self.titlebar = Gtk.Box(spacing=5, valign=Gtk.Align.CENTER)
         self.titlebar.get_style_context().add_class("title_bar")
@@ -281,6 +287,28 @@ class BasePanel(ScreenPanel):
         self.control["temp_box"].add(self.control["spoolman_box"])
         self.set_spoolman_refresh()
         self.fetch_spoolman()
+
+    def open_spool_shortcut(self, widget=None):
+        if self.spool_shortcut == "spoolman":
+            self._screen.show_panel("spoolman")
+            return
+        if self.spool_shortcut != "spool":
+            return
+        spool_data = None if self._printer is None else self._printer.active_spool
+        if spool_data is None:
+            active_spool_id = self._screen.spoolman_api.get_active_spool_id()
+            if active_spool_id:
+                spool_data = self._screen.spoolman_api.get_spool_details(active_spool_id)
+        if spool_data is None:
+            self._screen.show_panel("spoolman")
+            return
+
+        from panels.spoolman import SpoolmanSpool
+        if SpoolmanSpool.theme_path != self._screen.theme:
+            SpoolmanSpool.theme_path = self._screen.theme
+            SpoolmanSpool._spool_icon = None
+        spool = SpoolmanSpool(**spool_data)
+        self._screen.show_panel("spool_editor", extra=spool)
 
     def get_icon(self, device, img_size):
         if device.startswith("extruder"):
@@ -576,10 +604,17 @@ class BasePanel(ScreenPanel):
                 logging.info(f"Hidden sensors: {self.hidden_sensors}")
             else:
                 ScreenPanel.hidden_sensors = []
+            raw_spool_shortcut = self.ks_printer_cfg.get("spool_shortcut", fallback=None)
+            if isinstance(raw_spool_shortcut, str):
+                raw_spool_shortcut = raw_spool_shortcut.strip().lower()
+            self.spool_shortcut = (
+                raw_spool_shortcut if raw_spool_shortcut in {"spool", "spoolman"} else None
+            )
             self.spoolman_low_limit = self.ks_printer_cfg.getfloat("spool_low_limit", fallback=20)
         else:
             self.titlebar_items = []
             ScreenPanel.hidden_sensors = []
+            self.spool_shortcut = None
             self.spoolman_low_limit = 20
 
     def show_update_dialog(self):


### PR DESCRIPTION
### This PR adds an optional shortcut action to the Spoolman item in the title bar

The spool title-bar item can now be configured to open either the active spool editor or the Spoolman spool list when tapped.

## Changes

- Added `spool_shortcut` as a valid printer config option
- Made the title-bar Spoolman item clickable when a shortcut is configured
- Added support for two shortcut targets:
  - `spool` opens the active spool editor
  - `spoolman` opens the Spoolman spool list
- Falls back to the Spoolman list when `spool` is configured but no active spool is available
- Documented the new configuration option

## Configuration

```
spool_shortcut: spool

or:

spool_shortcut: spoolman
```

Tested on printer a works.