### PR TITLE
Add config-driven keybinding system for keyboard navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 KlipperScreen is a touchscreen GUI that interfaces with [Klipper](https://github.com/Klipper3d/klipper) via [Moonraker](https://github.com/arksine/moonraker). It allows you to switch between multiple printers and access them from a single location. Notably, it doesn't need to run on the same host as your printer; you can install it on another device and configure the IP address to connect to the printer.
 
+KlipperScreen also supports keyboard navigation and customizable shortcuts, enabling keyboard-only operation and alternative input devices like barcode scanners and arcade controls.
+
 ### Documentation
 
 For detailed information, [click here to access the documentation](https://klipperscreen.github.io/KlipperScreen/).

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -261,6 +261,60 @@ icon: heat-up
 panel: preheat
 ```
 
+## Keybindings
+
+Keybindings provide keyboard navigation and customizable shortcuts. See the [Keybindings documentation](Keybindings.md) for complete details.
+
+### Quick Start
+
+```{ .ini }
+# Enable default Escape/Backspace behavior
+[include ~/KlipperScreen/keybindings/default_navigation.cfg]
+```
+
+### Section Types
+
+The keybinding system uses four configuration section types:
+
+**Keygroups** - Reusable sets of keys:
+```{ .ini }
+[keygroup lower_case]
+keys = a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z
+```
+
+**Accumulators** - Buffers that collect keystrokes:
+```{ .ini }
+[accumulator gcode_input]
+# Auto-clear after 2 seconds of inactivity
+timeout = 2.0
+```
+
+**Keybindings** - Named actions bound to keys:
+```{ .ini }
+[keybinding emergency_stop]
+key = F1
+action = exec_gcode
+gcode = M112
+confirm = Execute EMERGENCY STOP?
+require_unlocked = false
+```
+
+**Panel Assignment** - Assign keybindings to panels:
+```{ .ini }
+# Active on all panels
+[panel __global]
+keybindings = emergency_stop,nav_home
+
+# Active only on move panel
+[panel move]
+keybindings = move_up,move_down
+```
+
+!!! note
+    Section names (keygroups and keybindings) must use snake_case (lowercase with underscores).
+
+See [Keybindings.md](Keybindings.md) for action types, examples, and the extension API.
+
 ## KlipperScreen behaviour towards configuration
 
 KlipperScreen will search for a configuration file in the following order:

--- a/docs/Keybindings.md
+++ b/docs/Keybindings.md
@@ -1,0 +1,270 @@
+# Keybindings
+
+Keybindings provide keyboard navigation and customizable shortcuts for KlipperScreen. This accessibility feature enables keyboard-only operation and supports alternative input devices like barcode scanners, RFID readers, and arcade controls.
+
+## Quick Start
+
+Enable default Escape/Backspace behavior:
+
+```ini title="KlipperScreen.conf"
+[include ~/KlipperScreen/keybindings/default_navigation.cfg]
+```
+
+Or use the comprehensive navigation example:
+
+```ini title="KlipperScreen.conf"
+[include ~/KlipperScreen/keybindings/examples/basic_navigation.cfg]
+```
+
+!!! note
+    Without a keybinding configuration, keyboard shortcuts are disabled. This is by design—keyboard functionality is opt-in.
+
+## Configuration Sections
+
+The keybinding system uses four section types:
+
+### Keygroups
+
+Reusable sets of keys. Names must use `snake_case` (lowercase with underscores).
+
+```ini
+[keygroup lower_case]
+keys = a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z
+
+[keygroup num_keys]
+keys = 0,1,2,3,4,5,6,7,8,9
+
+# Keygroups can reference other keygroups
+[keygroup alpha_numeric]
+keys = lower_case,upper_case,num_keys
+```
+
+Standard keygroups are provided in `keybindings/keygroups_us_ascii.cfg`.
+
+### Accumulators
+
+Buffers that collect keystrokes for multi-key sequences.
+
+```ini
+[accumulator gcode_input]
+# Auto-clear after 2 seconds of inactivity
+timeout = 2.0
+```
+
+### Keybindings
+
+Named actions bound to keys. Names must use `snake_case`.
+
+```ini
+[keybinding emergency_stop]
+key = F1
+action = exec_gcode
+gcode = M112
+confirm = Execute EMERGENCY STOP?
+# Works even when screen is locked (default is true)
+require_unlocked = false
+
+[keybinding accumulate_chars]
+# Bind multiple keys using a keygroup
+keys = alpha_numeric
+action = accumulate
+buffer = gcode_input
+```
+
+### Panel Assignment
+
+Assign keybindings to panels:
+
+```ini
+# Active on all panels
+[panel __global]
+keybindings = emergency_stop,nav_home
+
+# Active only on the move panel
+[panel move]
+keybindings = move_up,move_down
+```
+
+## Action Types
+
+| Action | Description | Required Fields |
+|--------|-------------|-----------------|
+| `accumulate` | Add key to buffer | `buffer` |
+| `gcode` | Execute buffer as gcode | `buffer` |
+| `exec_gcode` | Execute literal gcode | `gcode` |
+| `clear` | Clear buffer | `buffer` |
+| `backspace` | Remove last char | `buffer` |
+| `function` | Call handler with buffer | `function`, `buffer` (optional) |
+| `exec_function` | Call handler without args | `function` |
+| `panel` | Navigate to panel | `panel` |
+
+### Action Examples
+
+```ini
+# Execute accumulated gcode on Enter
+[keybinding execute_gcode]
+key = Return
+action = gcode
+buffer = gcode_input
+confirm = Execute this G-code?
+
+# Navigate to temperature panel
+[keybinding nav_temp]
+key = t
+action = panel
+panel = temperature
+
+# Quick movement
+[keybinding move_up]
+key = Page_Up
+action = exec_gcode
+gcode = G91\nG1 Z1 F300\nG90
+
+# Custom function handler
+[keybinding custom_action]
+key = F5
+action = exec_function
+function = my_handler
+```
+
+## Key Naming
+
+KlipperScreen uses GTK key names for keyboard keys:
+
+**Common keys:**
+- Letters: `a`-`z`, `A`-`Z`
+- Numbers: `0`-`9`
+- Function: `F1`-`F12`
+- Navigation: `Left`, `Right`, `Up`, `Down`, `Home`, `End`, `Page_Up`, `Page_Down`
+- Special: `Return`, `Escape`, `BackSpace`, `Delete`, `Insert`, `Tab`, `space`
+- Modifiers: `Shift_L`, `Shift_R`, `Control_L`, `Control_R`, `Alt_L`, `Alt_R`
+
+!!! tip
+    GTK key names use PascalCase or Mixed_Case (`BackSpace`, `Page_Up`). Custom keygroup names must use snake_case to avoid collisions.
+
+## Advanced Configuration
+
+### Accumulator Pattern
+
+Collect keystrokes and execute on trigger:
+
+```ini
+[accumulator gcode_buffer]
+timeout = 2.0
+
+[keybinding collect_text]
+keys = alpha_numeric,special_symbols
+action = accumulate
+buffer = gcode_buffer
+
+[keybinding execute_on_enter]
+key = Return
+action = gcode
+buffer = gcode_buffer
+
+[keybinding clear_on_escape]
+key = Escape
+action = clear
+buffer = gcode_buffer
+
+[panel __global]
+keybindings = collect_text,execute_on_enter,clear_on_escape
+```
+
+### Panel-Specific Shortcuts
+
+```ini
+[keybinding move_z_up]
+key = Page_Up
+action = exec_gcode
+gcode = G91\nG1 Z1 F300\nG90
+
+[keybinding move_z_down]
+key = Page_Down
+action = exec_gcode
+gcode = G91\nG1 Z-1 F300\nG90
+
+# Only active on move panel
+[panel move]
+keybindings = move_z_up,move_z_down
+```
+
+### Emergency Actions
+
+Emergency actions can work even when the screen is locked:
+
+```ini
+[keybinding emergency_stop]
+key = F1
+action = exec_gcode
+gcode = M112
+confirm = Execute EMERGENCY STOP?
+require_unlocked = false
+
+[keybinding emergency_pause]
+key = F2
+action = exec_gcode
+gcode = PAUSE
+require_unlocked = false
+
+[panel __global]
+keybindings = emergency_stop,emergency_pause
+```
+
+## Extension API
+
+Extensions can register custom handler functions:
+
+```python
+# In your extension __init__
+screen.keybinding_system.register_handler("my_handler", self.my_method)
+
+def my_method(self, buffer_contents):
+    # buffer_contents is empty string for exec_function action
+    logging.info(f"Handler called with: {buffer_contents}")
+    # Your custom logic here
+```
+
+Reference in config:
+
+```ini
+[keybinding custom_action]
+key = F5
+action = function
+function = my_handler
+buffer = user_input
+```
+
+## Security
+
+When the screen locks, all accumulator buffers are automatically cleared for security. Only keybindings with `require_unlocked = false` function when locked.
+
+!!! warning "Security Notice"
+    Only use `require_unlocked = false` for emergency actions. Regular shortcuts should require the screen to be unlocked.
+
+## Troubleshooting
+
+**Keys not working:**
+- Verify you've included a keybinding config file
+- Check logs for "Keybinding system initialized"
+- Ensure keygroup/keybinding names use snake_case
+
+**Text entry broken:**
+- Text entry widgets automatically receive keyboard input
+- Keybindings don't intercept text entry focus
+
+**Escape/Backspace not working:**
+- These are no longer hardcoded
+- Include `default_navigation.cfg` or define custom bindings
+
+**Screensaver interference:**
+- Any key wakes the screensaver
+- Keybindings only process after wake
+
+## Example Configurations
+
+See the `keybindings/examples/` directory:
+- `basic_navigation.cfg` - Simple navigation shortcuts
+- `advanced_shortcuts.cfg` - Accumulator usage and complex actions
+
+See `keybindings/keygroups_us_ascii.cfg` for standard keygroup definitions.

--- a/keybindings/README.md
+++ b/keybindings/README.md
@@ -1,0 +1,156 @@
+# KlipperScreen Keybinding System
+
+This directory contains the keybinding system configuration files for KlipperScreen.
+
+## Overview
+
+The keybinding system provides a flexible, config-driven way to bind keyboard keys to actions in KlipperScreen. This improves accessibility and enables alternative input methods beyond touchscreen interaction.
+
+## Features
+
+- **Keygroups**: Reusable sets of keys (e.g., all letters, all digits)
+- **Keybindings**: Named actions bound to specific keys or keygroups
+- **Accumulators**: Buffers that collect keystrokes for multi-key sequences
+- **Panel-specific contexts**: Different keybindings per panel
+- **Lock state awareness**: Certain bindings can work even when screen is locked
+
+## Quick Start
+
+To enable keyboard navigation with default Escape/Backspace behavior, include in your `KlipperScreen.conf`:
+
+```ini
+[include /path/to/KlipperScreen/keybindings/default_navigation.cfg]
+```
+
+Or for more comprehensive keyboard shortcuts:
+
+```ini
+[include /path/to/KlipperScreen/keybindings/examples/basic_navigation.cfg]
+```
+
+## Configuration Syntax
+
+### Keygroups
+
+Define reusable sets of keys. Keygroup names MUST use snake_case (lowercase with underscores):
+
+```ini
+[keygroup lower_case]
+keys = a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z
+
+[keygroup my_custom_keys]
+keys = lower_case,upper_case,1,2,3  # Can reference other keygroups
+```
+
+### Accumulators
+
+Define buffers that collect keystrokes:
+
+```ini
+[accumulator gcode_input]
+timeout = 2.0  # Auto-clear after 2 seconds of inactivity
+```
+
+### Keybindings
+
+Bind keys to actions. Keybinding names MUST use snake_case:
+
+```ini
+[keybinding emergency_stop]
+key = F1  # Single key
+action = exec_gcode
+gcode = M112
+confirm = Execute emergency stop?  # Optional confirmation
+require_unlocked = false  # Works even when locked
+
+[keybinding accumulate_text]
+keys = alpha_numeric,special_symbols  # Multiple keys via keygroups
+action = accumulate
+buffer = gcode_input
+```
+
+### Panel Assignment
+
+Assign keybindings to panels:
+
+```ini
+[panel __global]
+keybindings = emergency_stop,nav_home  # Active on all panels
+
+[panel move]
+keybindings = move_up,move_down  # Only active on move panel
+```
+
+## Action Types
+
+- `accumulate` - Add key to buffer
+- `gcode` - Execute buffer contents as gcode
+- `exec_gcode` - Execute literal gcode string
+- `clear` - Clear buffer
+- `backspace` - Remove last char from buffer
+- `function` - Call registered handler function with buffer
+- `panel` - Navigate to panel
+- `exec_function` - Call handler with no args
+
+## Naming Conventions
+
+- **GTK key names**: PascalCase or Mixed_Case (`Return`, `Escape`, `BackSpace`, `Shift_L`)
+- **Keygroup names**: snake_case with underscore (`lower_case`, `num_keys`, `special_symbols`)
+- **Keybinding names**: snake_case with underscore (`emergency_stop`, `nav_home`)
+
+This convention prevents naming collisions between GTK keys and custom keygroups.
+
+## Files
+
+- `keygroups_us_ascii.cfg` - Standard US ASCII keyboard keygroups
+- `default_navigation.cfg` - Default Escape/Backspace behavior (mimics legacy KlipperScreen)
+- `examples/basic_navigation.cfg` - Simple navigation shortcuts
+- `examples/advanced_shortcuts.cfg` - Advanced usage with accumulators
+- `test_config.cfg` - Test configuration for verification
+
+## Extension API
+
+Extensions can register custom handler functions:
+
+```python
+# In your extension __init__
+screen.keybinding_system.register_handler("my_handler", self.my_method)
+
+def my_method(self, buffer_contents):
+    # Custom processing logic
+    pass
+```
+
+Then reference in config:
+
+```ini
+[keybinding my_action]
+key = F5
+action = function
+function = my_handler
+buffer = user_input
+```
+
+## Accessibility Benefits
+
+- Keyboard-only navigation for users who prefer or require it
+- Support for HID input devices (barcode scanners, RFID readers, etc.)
+- Customizable shortcuts for frequent operations
+- Headless/kiosk mode operation
+- Alternative input methods for makerspace environments
+
+## Backward Compatibility
+
+The keybinding system is fully backward compatible. **However, keyboard functionality is now opt-in via configuration.**
+
+- **Without any keybinding config**: No keyboard shortcuts work (not even Escape/Backspace)
+- **With default_navigation.cfg**: Escape and Backspace work as they did in legacy KlipperScreen
+- **With custom config**: Only your configured keybindings are active
+
+This design makes all keyboard behavior explicit and config-driven. To restore the original Escape/Backspace behavior, simply include `default_navigation.cfg` in your configuration.
+
+**Why this change?** Previously, Escape and Backspace were hardcoded in the event handler, which created confusion when users wanted to customize those keys. Now, all keyboard behavior is defined in config files, making it clear what keys do what.
+
+## Security
+
+When the screen is locked, all accumulator buffers are automatically cleared for security. Only keybindings with `require_unlocked = false` will function when locked (intended for emergency actions only).

--- a/keybindings/default_navigation.cfg
+++ b/keybindings/default_navigation.cfg
@@ -1,0 +1,24 @@
+# Default keyboard navigation (mimics legacy KlipperScreen behavior)
+#
+# This file provides the same Escape/Backspace behavior that was previously
+# hardcoded in KlipperScreen. Include this if you want those keys to work
+# without defining custom keybindings.
+#
+# To use, add to your KlipperScreen.conf:
+#   [include /path/to/KlipperScreen/keybindings/default_navigation.cfg]
+#
+# If you want custom keyboard shortcuts instead, use basic_navigation.cfg
+# or create your own keybinding configuration.
+
+[keybinding default_escape]
+key = Escape
+action = exec_function
+function = go_back_home
+
+[keybinding default_backspace]
+key = BackSpace
+action = exec_function
+function = go_back
+
+[panel __global]
+keybindings = default_escape,default_backspace

--- a/keybindings/examples/advanced_shortcuts.cfg
+++ b/keybindings/examples/advanced_shortcuts.cfg
@@ -1,0 +1,73 @@
+# Advanced keyboard shortcuts with accumulator usage
+# This example demonstrates text input accumulation and custom actions
+#
+# Include in your KlipperScreen.conf:
+#   [include /path/to/KlipperScreen/keybindings/examples/advanced_shortcuts.cfg]
+
+[include ../keygroups_us_ascii.cfg]
+
+# Define an accumulator for gcode input
+[accumulator gcode_input]
+timeout = 2.0
+
+# Accumulate text input (all alphanumeric and common symbols)
+[keybinding accumulate_text]
+keys = alpha_numeric,special_symbols
+action = accumulate
+buffer = gcode_input
+
+# Execute accumulated gcode on Enter
+[keybinding execute_accumulated]
+key = Return
+action = gcode
+buffer = gcode_input
+confirm = Execute this G-code?
+
+# Clear buffer on Escape
+[keybinding clear_buffer]
+key = Escape
+action = clear
+buffer = gcode_input
+
+# Backspace support
+[keybinding buffer_backspace]
+key = BackSpace
+action = backspace
+buffer = gcode_input
+
+# Quick movement shortcuts (no confirmation for safety-critical ops)
+[keybinding move_z_up]
+key = Page_Up
+action = exec_gcode
+gcode = G91\nG1 Z1 F300\nG90
+
+[keybinding move_z_down]
+key = Page_Down
+action = exec_gcode
+gcode = G91\nG1 Z-1 F300\nG90
+
+[keybinding home_all]
+key = Home
+action = exec_gcode
+gcode = G28
+confirm = Home all axes?
+
+# Temperature presets
+[keybinding preheat_pla]
+key = F3
+action = exec_gcode
+gcode = M104 S200\nM140 S60
+
+[keybinding preheat_abs]
+key = F4
+action = exec_gcode
+gcode = M104 S240\nM140 S100
+
+[keybinding cooldown]
+key = F5
+action = exec_gcode
+gcode = M104 S0\nM140 S0
+
+# Active globally
+[panel __global]
+keybindings = accumulate_text,execute_accumulated,clear_buffer,buffer_backspace,move_z_up,move_z_down,home_all,preheat_pla,preheat_abs,cooldown

--- a/keybindings/examples/basic_navigation.cfg
+++ b/keybindings/examples/basic_navigation.cfg
@@ -1,0 +1,58 @@
+# Basic keyboard navigation configuration for KlipperScreen
+# This example demonstrates how to set up simple keyboard shortcuts
+# for navigation and emergency actions.
+#
+# Include in your KlipperScreen.conf:
+#   [include /path/to/KlipperScreen/keybindings/examples/basic_navigation.cfg]
+
+[include ../keygroups_us_ascii.cfg]
+
+# Navigate to main menu with 'h' key (like "home")
+[keybinding nav_home]
+key = h
+action = panel
+panel = main
+
+# Navigate to temperature panel with 't' key
+[keybinding nav_temperature]
+key = t
+action = panel
+panel = temperature
+
+# Navigate to move panel with 'm' key
+[keybinding nav_move]
+key = m
+action = panel
+panel = move
+
+# Go back with Escape (mimics default KlipperScreen behavior)
+[keybinding nav_escape]
+key = Escape
+action = exec_function
+function = go_back_home
+
+# Go back one level with Backspace
+[keybinding nav_backspace]
+key = BackSpace
+action = exec_function
+function = go_back
+
+# Emergency stop with F1 - works even when locked
+[keybinding emergency_stop]
+key = F1
+action = exec_gcode
+gcode = M112
+confirm = Execute EMERGENCY STOP?
+require_unlocked = false
+
+# Emergency pause with F2
+[keybinding emergency_pause]
+key = F2
+action = exec_gcode
+gcode = PAUSE
+confirm = Pause print?
+require_unlocked = false
+
+# Active on all panels
+[panel __global]
+keybindings = nav_home,nav_temperature,nav_move,nav_escape,nav_backspace,emergency_stop,emergency_pause

--- a/keybindings/keygroups_us_ascii.cfg
+++ b/keybindings/keygroups_us_ascii.cfg
@@ -1,0 +1,39 @@
+# Standard US ASCII keyboard keygroups
+# GTK key names use PascalCase/Mixed_Case (Return, Escape, BackSpace, Shift_L)
+# Custom keygroups MUST use snake_case (lowercase with underscores)
+#
+# This file can be included in your KlipperScreen.conf:
+#   [include /path/to/KlipperScreen/keybindings/keygroups_us_ascii.cfg]
+
+[keygroup lower_case]
+keys = a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z
+
+[keygroup upper_case]
+keys = A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z
+
+[keygroup num_keys]
+keys = 0,1,2,3,4,5,6,7,8,9
+
+[keygroup letter_keys]
+keys = lower_case,upper_case
+
+[keygroup alpha_numeric]
+keys = letter_keys,num_keys
+
+[keygroup ascii_symbols]
+keys = minus,equal,bracketleft,bracketright,semicolon,apostrophe,comma,period,slash,backslash,space,colon
+
+[keygroup special_symbols]
+keys = minus,colon,slash,underscore,space
+
+[keygroup modifier_keys]
+keys = Shift_L,Shift_R,Control_L,Control_R,Alt_L,Alt_R,Super_L,Super_R
+
+[keygroup function_keys]
+keys = F1,F2,F3,F4,F5,F6,F7,F8,F9,F10,F11,F12
+
+[keygroup nav_keys]
+keys = Left,Right,Up,Down,Home,End,Page_Up,Page_Down
+
+[keygroup edit_keys]
+keys = BackSpace,Delete,Insert,Tab,Return,Escape

--- a/ks_includes/config.py
+++ b/ks_includes/config.py
@@ -264,6 +264,26 @@ class KlipperScreenConfig:
                 numbers = [f"{option}" for option in config[section] if option != "gcode"]
             elif section.startswith("menu "):
                 strs = ("name", "icon", "panel", "method", "params", "enable", "confirm", "style")
+            elif section.startswith("keygroup "):
+                keygroup_name = section[9:].strip()
+                if not re.match(r"^[a-z][a-z0-9_]*$", keygroup_name):
+                    self.errors.append(
+                        f"Section [{section}]: name must be snake_case (lowercase with underscores)"
+                    )
+                strs = ("keys",)
+            elif section.startswith("accumulator "):
+                strs = ("handler",)
+                numbers = ("timeout",)
+            elif section.startswith("keybinding "):
+                keybinding_name = section[11:].strip()
+                if not re.match(r"^[a-z][a-z0-9_]*$", keybinding_name):
+                    self.errors.append(
+                        f"Section [{section}]: name must be snake_case (lowercase with underscores)"
+                    )
+                strs = ("key", "keys", "action", "buffer", "gcode", "panel", "confirm", "function")
+                bools = ("require_unlocked",)
+            elif section.startswith("panel "):
+                strs = ("keybindings",)
             elif (
                 section.startswith("graph")
                 or section.startswith("displayed_macros")

--- a/ks_includes/keybinding_system.py
+++ b/ks_includes/keybinding_system.py
@@ -1,0 +1,551 @@
+import logging
+import re
+import time
+from typing import Any, Callable, Dict, List, Optional, Set
+
+import gi
+
+gi.require_version("Gdk", "3.0")
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gdk, Gtk, Pango
+
+
+class KeyGroupManager:
+    """Manages keygroup definitions and resolves keygroup references."""
+
+    def __init__(self, config):
+        self.groups: Dict[str, List[str]] = {}
+        self._config = config
+        self._load_keygroups()
+        self._validate_no_cycles()
+
+    def _load_keygroups(self):
+        """Load all [keygroup name] sections from config."""
+        for section in self._config.get_config().sections():
+            if section.startswith("keygroup "):
+                name = section[9:].strip()
+
+                if not self._validate_keygroup_name(name):
+                    logging.error(f"Invalid keygroup name: {name}")
+                    continue
+
+                keys_str = self._config.get_config().get(section, "keys", fallback="")
+                if not keys_str:
+                    logging.warning(f"Keygroup [{section}] has no keys defined")
+                    continue
+
+                # Store raw key list (will be resolved recursively later)
+                self.groups[name] = [k.strip() for k in keys_str.split(",") if k.strip()]
+                logging.debug(f"Loaded keygroup '{name}' with {len(self.groups[name])} items")
+
+    def _validate_keygroup_name(self, name: str) -> bool:
+        """Validate keygroup name follows snake_case convention."""
+        if not re.match(r"^[a-z][a-z0-9_]*$", name):
+            return False
+
+        # Check for collision with common GTK key names (lowercase versions)
+        gtk_reserved = {
+            "return",
+            "escape",
+            "backspace",
+            "delete",
+            "insert",
+            "tab",
+            "home",
+            "end",
+            "space",
+            "left",
+            "right",
+            "up",
+            "down",
+        }
+        if name in gtk_reserved:
+            logging.error(f"Keygroup name '{name}' conflicts with GTK key name")
+            return False
+
+        return True
+
+    def resolve_keys(self, keys_string: str, visited: Optional[Set[str]] = None) -> List[str]:
+        """
+        Resolve a comma-separated list of keys and keygroup references.
+
+        Args:
+            keys_string: Comma-separated keys and keygroup names
+            visited: Set of keygroup names already visited (for cycle detection)
+
+        Returns:
+            Flat list of resolved key names
+        """
+        if visited is None:
+            visited = set()
+
+        result = []
+        for item in keys_string.split(","):
+            item = item.strip()
+            if not item:
+                continue
+
+            # Check if it's a keygroup reference
+            if item in self.groups:
+                if item in visited:
+                    logging.error(f"Circular reference detected in keygroup '{item}'")
+                    continue
+
+                visited.add(item)
+                # Recursively resolve keygroup
+                for sub_item in self.groups[item]:
+                    if sub_item in self.groups:
+                        result.extend(self.resolve_keys(sub_item, visited.copy()))
+                    else:
+                        result.append(sub_item)
+                visited.discard(item)
+            else:
+                # Literal key name
+                result.append(item)
+
+        return result
+
+    def _validate_no_cycles(self):
+        """Detect circular references in keygroup definitions."""
+        for group_name in self.groups:
+            if not self._check_cycle(group_name, set()):
+                logging.error(f"Circular reference detected in keygroup '{group_name}'")
+
+    def _check_cycle(self, group_name: str, visited: Set[str]) -> bool:
+        """
+        Recursively check for cycles starting from group_name.
+
+        Returns:
+            True if no cycle detected, False if cycle found
+        """
+        if group_name in visited:
+            return False
+
+        visited.add(group_name)
+
+        if group_name in self.groups:
+            for item in self.groups[group_name]:
+                if item in self.groups:
+                    if not self._check_cycle(item, visited.copy()):
+                        return False
+
+        return True
+
+
+class AccumulatorManager:
+    """Manages keystroke accumulator buffers."""
+
+    def __init__(self, config):
+        self.buffers: Dict[str, Dict[str, Any]] = {}
+        self._config = config
+        self._load_accumulators()
+
+    def _load_accumulators(self):
+        """Load all [accumulator name] sections from config."""
+        for section in self._config.get_config().sections():
+            if section.startswith("accumulator "):
+                name = section[12:].strip()
+
+                timeout = self._config.get_config().getfloat(section, "timeout", fallback=1.0)
+                handler = self._config.get_config().get(section, "handler", fallback=None)
+
+                self.buffers[name] = {
+                    "buffer": "",
+                    "timeout": timeout,
+                    "last_update": 0,
+                    "handler": handler,
+                }
+                logging.debug(f"Loaded accumulator '{name}' with timeout {timeout}s")
+
+    def add_char(self, buffer_name: str, char: str):
+        """Add character to buffer, auto-clear if timeout exceeded."""
+        if buffer_name not in self.buffers:
+            logging.warning(f"Accumulator '{buffer_name}' not defined")
+            return
+
+        buf = self.buffers[buffer_name]
+        current_time = time.time()
+
+        # Check timeout
+        if buf["last_update"] > 0 and (current_time - buf["last_update"]) > buf["timeout"]:
+            buf["buffer"] = ""
+
+        buf["buffer"] += char
+        buf["last_update"] = current_time
+        logging.debug(f"Accumulator '{buffer_name}': '{buf['buffer']}'")
+
+    def get_buffer(self, buffer_name: str) -> str:
+        """Get current buffer contents."""
+        if buffer_name not in self.buffers:
+            return ""
+        return self.buffers[buffer_name]["buffer"]
+
+    def clear(self, buffer_name: str):
+        """Clear buffer contents."""
+        if buffer_name in self.buffers:
+            self.buffers[buffer_name]["buffer"] = ""
+            self.buffers[buffer_name]["last_update"] = 0
+            logging.debug(f"Cleared accumulator '{buffer_name}'")
+
+    def clear_all(self):
+        """Clear all buffers (used when locking screen)."""
+        for name in self.buffers:
+            self.clear(name)
+
+    def backspace(self, buffer_name: str):
+        """Remove last character from buffer."""
+        if buffer_name in self.buffers and self.buffers[buffer_name]["buffer"]:
+            self.buffers[buffer_name]["buffer"] = self.buffers[buffer_name]["buffer"][:-1]
+            logging.debug(f"Backspace in '{buffer_name}': '{self.buffers[buffer_name]['buffer']}'")
+
+    def get_handler(self, buffer_name: str) -> Optional[str]:
+        """Get registered handler name for buffer."""
+        if buffer_name in self.buffers:
+            return self.buffers[buffer_name]["handler"]
+        return None
+
+
+class KeyBindingManager:
+    """Manages keybinding definitions."""
+
+    def __init__(self, config, keygroup_manager: KeyGroupManager):
+        self.bindings: Dict[str, Dict[str, Any]] = {}
+        self._config = config
+        self._keygroup_manager = keygroup_manager
+        self._load_keybindings()
+
+    def _load_keybindings(self):
+        """Load all [keybinding name] sections from config."""
+        for section in self._config.get_config().sections():
+            if section.startswith("keybinding "):
+                name = section[11:].strip()
+
+                # Extract all keybinding fields
+                binding = {
+                    "name": name,
+                    "key": self._config.get_config().get(section, "key", fallback=None),
+                    "keys": self._config.get_config().get(section, "keys", fallback=None),
+                    "action": self._config.get_config().get(section, "action", fallback=None),
+                    "buffer": self._config.get_config().get(section, "buffer", fallback=None),
+                    "gcode": self._config.get_config().get(section, "gcode", fallback=None),
+                    "panel": self._config.get_config().get(section, "panel", fallback=None),
+                    "confirm": self._config.get_config().get(section, "confirm", fallback=None),
+                    "function": self._config.get_config().get(section, "function", fallback=None),
+                    "require_unlocked": self._config.get_config().getboolean(
+                        section, "require_unlocked", fallback=True
+                    ),
+                }
+
+                if not binding["action"]:
+                    logging.warning(f"Keybinding [{section}] has no action defined")
+                    continue
+
+                # Expand keygroup references if using 'keys' field
+                if binding["keys"]:
+                    binding["resolved_keys"] = self._keygroup_manager.resolve_keys(binding["keys"])
+                elif binding["key"]:
+                    binding["resolved_keys"] = [binding["key"]]
+                else:
+                    logging.warning(f"Keybinding [{section}] has neither 'key' nor 'keys' defined")
+                    continue
+
+                self.bindings[name] = binding
+                logging.debug(f"Loaded keybinding '{name}' with action '{binding['action']}'")
+
+    def get_binding(self, name: str) -> Optional[Dict[str, Any]]:
+        """Get keybinding definition by name."""
+        return self.bindings.get(name)
+
+    def get_all_bindings(self) -> Dict[str, Dict[str, Any]]:
+        """Get all keybinding definitions."""
+        return self.bindings
+
+
+class KeyBindingResolver:
+    """Resolves active keybindings based on current context."""
+
+    def __init__(self, config, keybinding_manager: KeyBindingManager):
+        self.panel_bindings: Dict[str, List[str]] = {}
+        self._config = config
+        self._keybinding_manager = keybinding_manager
+        self._load_panel_bindings()
+
+    def _load_panel_bindings(self):
+        """Load all [panel name] sections from config."""
+        for section in self._config.get_config().sections():
+            if section.startswith("panel "):
+                name = section[6:].strip()
+
+                keybindings_str = self._config.get_config().get(section, "keybindings", fallback="")
+                if keybindings_str:
+                    keybindings = [k.strip() for k in keybindings_str.split(",") if k.strip()]
+                    self.panel_bindings[name] = keybindings
+                    logging.debug(f"Loaded panel '{name}' with {len(keybindings)} keybindings")
+
+    def get_active_bindings(self, screen) -> Dict[str, Dict[str, Any]]:
+        """
+        Determine active keybindings based on current context.
+
+        Returns:
+            Dictionary mapping key_name -> binding_definition
+        """
+        # Start with global bindings
+        active_binding_names = self.panel_bindings.get("__global", []).copy()
+
+        # Add current panel bindings
+        if hasattr(screen, "_cur_panels") and screen._cur_panels:
+            current_panel = screen._cur_panels[-1]
+            panel_name = (
+                current_panel
+                if isinstance(current_panel, str)
+                else current_panel.__class__.__name__
+            )
+
+            if panel_name in self.panel_bindings:
+                active_binding_names.extend(self.panel_bindings[panel_name])
+
+        # Resolve binding names to actual bindings
+        active_bindings = {}
+        for binding_name in active_binding_names:
+            binding = self._keybinding_manager.get_binding(binding_name)
+            if binding:
+                # Map each resolved key to this binding
+                for key in binding["resolved_keys"]:
+                    # Later bindings override earlier ones (last defined wins)
+                    active_bindings[key] = binding
+
+        # Filter by lock state if locked
+        if hasattr(screen, "lock") and screen.lock.is_locked():
+            active_bindings = {
+                key: binding
+                for key, binding in active_bindings.items()
+                if not binding["require_unlocked"]
+            }
+
+        return active_bindings
+
+
+class KeyBindingSystem:
+    """Main coordinator for the keybinding system."""
+
+    def __init__(
+        self,
+        screen,
+        keybinding_resolver: KeyBindingResolver,
+        accumulator_manager: AccumulatorManager,
+    ):
+        self._screen = screen
+        self._resolver = keybinding_resolver
+        self._accumulator_manager = accumulator_manager
+        self._handlers: Dict[str, Callable] = {}
+
+    def register_handler(self, name: str, handler: Callable):
+        """Register a custom function handler."""
+        self._handlers[name] = handler
+        logging.info(f"Registered keybinding handler: {name}")
+
+    def handle_key_event(self, event) -> bool:
+        """
+        Handle key press event.
+
+        Returns:
+            True if event was handled, False to pass through
+        """
+        keyval = event.keyval
+        keyname = Gdk.keyval_name(keyval)
+
+        if not keyname:
+            return False
+
+        # Get active bindings for current context
+        active_bindings = self._resolver.get_active_bindings(self._screen)
+
+        if keyname not in active_bindings:
+            return False
+
+        binding = active_bindings[keyname]
+        action = binding["action"]
+
+        logging.debug(f"Key '{keyname}' triggered action '{action}'")
+
+        # Execute action
+        try:
+            if action == "accumulate":
+                self._action_accumulate(binding, keyname)
+            elif action == "gcode":
+                self._action_gcode(binding)
+            elif action == "exec_gcode":
+                self._action_exec_gcode(binding)
+            elif action == "clear":
+                self._action_clear(binding)
+            elif action == "backspace":
+                self._action_backspace(binding)
+            elif action == "function":
+                self._action_function(binding)
+            elif action == "panel":
+                self._action_panel(binding)
+            elif action == "exec_function":
+                self._action_exec_function(binding)
+            else:
+                logging.warning(f"Unknown action type: {action}")
+                return False
+
+            return True
+        except Exception as e:
+            logging.exception(f"Error executing keybinding action '{action}': {e}")
+            return False
+
+    def _action_accumulate(self, binding: Dict[str, Any], keyname: str):
+        """Add key to accumulator buffer."""
+        buffer_name = binding.get("buffer")
+        if not buffer_name:
+            logging.warning("Accumulate action requires 'buffer' field")
+            return
+
+        self._accumulator_manager.add_char(buffer_name, keyname)
+
+    def _action_gcode(self, binding: Dict[str, Any]):
+        """Execute buffer contents as gcode."""
+        buffer_name = binding.get("buffer")
+        if not buffer_name:
+            logging.warning("Gcode action requires 'buffer' field")
+            return
+
+        gcode = self._accumulator_manager.get_buffer(buffer_name)
+        if not gcode:
+            logging.debug("Buffer empty, nothing to execute")
+            return
+
+        # Show confirmation dialog if configured
+        if binding.get("confirm"):
+            self._show_keybinding_confirm(binding["confirm"], lambda: self._execute_gcode(gcode))
+        else:
+            self._execute_gcode(gcode)
+
+    def _action_exec_gcode(self, binding: Dict[str, Any]):
+        """Execute literal gcode string."""
+        gcode = binding.get("gcode")
+        if not gcode:
+            logging.warning("Exec_gcode action requires 'gcode' field")
+            return
+
+        # Show confirmation dialog if configured
+        if binding.get("confirm"):
+            self._show_keybinding_confirm(binding["confirm"], lambda: self._execute_gcode(gcode))
+        else:
+            self._execute_gcode(gcode)
+
+    def _execute_gcode(self, gcode: str):
+        """Execute gcode via printer interface."""
+        if hasattr(self._screen, "_printer") and self._screen._printer:
+            self._screen._printer.gcode_script(gcode)
+            logging.info(f"Executed gcode: {gcode[:50]}...")
+        else:
+            logging.error("Printer interface not available")
+
+    def _action_clear(self, binding: Dict[str, Any]):
+        """Clear accumulator buffer."""
+        buffer_name = binding.get("buffer")
+        if not buffer_name:
+            logging.warning("Clear action requires 'buffer' field")
+            return
+
+        self._accumulator_manager.clear(buffer_name)
+
+    def _action_backspace(self, binding: Dict[str, Any]):
+        """Remove last character from buffer."""
+        buffer_name = binding.get("buffer")
+        if not buffer_name:
+            logging.warning("Backspace action requires 'buffer' field")
+            return
+
+        self._accumulator_manager.backspace(buffer_name)
+
+    def _action_function(self, binding: Dict[str, Any]):
+        """Call registered handler function with buffer contents."""
+        function_name = binding.get("function")
+        buffer_name = binding.get("buffer")
+
+        if not function_name:
+            logging.warning("Function action requires 'function' field")
+            return
+
+        if function_name not in self._handlers:
+            logging.error(f"Handler '{function_name}' not registered")
+            return
+
+        buffer_contents = self._accumulator_manager.get_buffer(buffer_name) if buffer_name else ""
+
+        # Show confirmation dialog if configured
+        if binding.get("confirm"):
+            self._show_keybinding_confirm(
+                binding["confirm"], lambda: self._handlers[function_name](buffer_contents)
+            )
+        else:
+            self._handlers[function_name](buffer_contents)
+
+    def _action_exec_function(self, binding: Dict[str, Any]):
+        """Call registered handler function without arguments."""
+        function_name = binding.get("function")
+
+        if not function_name:
+            logging.warning("Exec_function action requires 'function' field")
+            return
+
+        if function_name not in self._handlers:
+            logging.error(f"Handler '{function_name}' not registered")
+            return
+
+        # Show confirmation dialog if configured
+        if binding.get("confirm"):
+            self._show_keybinding_confirm(
+                binding["confirm"], lambda: self._handlers[function_name]()
+            )
+        else:
+            self._handlers[function_name]()
+
+    def _action_panel(self, binding: Dict[str, Any]):
+        """Navigate to panel."""
+        panel_name = binding.get("panel")
+        if not panel_name:
+            logging.warning("Panel action requires 'panel' field")
+            return
+
+        if hasattr(self._screen, "show_panel"):
+            self._screen.show_panel(panel_name)
+            logging.info(f"Navigated to panel: {panel_name}")
+        else:
+            logging.error("Screen does not support panel navigation")
+
+    def on_lock(self):
+        """Called when screen is locked - clear all accumulators for security."""
+        self._accumulator_manager.clear_all()
+        logging.info("Keybinding system: cleared all accumulators on lock")
+
+    def _show_keybinding_confirm(self, text: str, callback: Callable):
+        """Show confirmation dialog for keybinding action."""
+        if not hasattr(self._screen, "gtk"):
+            logging.error("GTK interface not available for confirmation dialog")
+            return
+
+        buttons = [
+            {"name": "Accept", "response": Gtk.ResponseType.OK, "style": "dialog-info"},
+            {"name": "Cancel", "response": Gtk.ResponseType.CANCEL, "style": "dialog-error"},
+        ]
+
+        label = Gtk.Label(
+            hexpand=True,
+            vexpand=True,
+            halign=Gtk.Align.CENTER,
+            valign=Gtk.Align.CENTER,
+            wrap=True,
+            wrap_mode=Pango.WrapMode.WORD_CHAR,
+        )
+        label.set_markup(text)
+
+        def response_handler(dialog, response_id):
+            self._screen.gtk.remove_dialog(dialog)
+            if response_id == Gtk.ResponseType.OK:
+                callback()
+
+        self._screen.gtk.Dialog("KlipperScreen", buttons, label, response_handler)

--- a/ks_includes/widgets/lockscreen.py
+++ b/ks_includes/widgets/lockscreen.py
@@ -41,6 +41,11 @@ class LockScreen:
     def lock(self, widget):
         self.screen._menu_go_back(None, True)
         logging.info("Locked the screen")
+
+        # Clear keybinding accumulators for security
+        if hasattr(self.screen, "keybinding_system") and self.screen.keybinding_system:
+            self.screen.keybinding_system.on_lock()
+
         close = Gtk.Button()
         close.connect("clicked", self.unlock)
         self.lock_box = Gtk.Box(

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,7 @@ nav:
       - Installation.md
       - Updating.md
       - Configuration.md
+      - Keybindings.md
       - Quicktips.md
       - Macros: macros.md
       - Thumbnails.md

--- a/screen.py
+++ b/screen.py
@@ -26,6 +26,13 @@ from jinja2 import Environment
 from ks_includes import functions
 from ks_includes.config import KlipperScreenConfig
 from ks_includes.files import KlippyFiles
+from ks_includes.keybinding_system import (
+    AccumulatorManager,
+    KeyBindingManager,
+    KeyBindingResolver,
+    KeyBindingSystem,
+    KeyGroupManager,
+)
 from ks_includes.KlippyGtk import KlippyGtk
 from ks_includes.KlippyRest import KlippyRest
 from ks_includes.KlippyWebsocket import KlippyWebsocket
@@ -151,6 +158,27 @@ class KlipperScreen(Gtk.Window):
         self.style_provider = Gtk.CssProvider()
         self.screensaver = ScreenSaver(self)
         self.lock_screen = LockScreen(self)
+
+        # Initialize keybinding system
+        try:
+            self.keygroup_manager = KeyGroupManager(self._config)
+            self.accumulator_manager = AccumulatorManager(self._config)
+            self.keybinding_manager = KeyBindingManager(self._config, self.keygroup_manager)
+            self.keybinding_resolver = KeyBindingResolver(self._config, self.keybinding_manager)
+            self.keybinding_system = KeyBindingSystem(
+                self, self.keybinding_resolver, self.accumulator_manager
+            )
+            # Register built-in handlers
+            self.keybinding_system.register_handler("go_back", lambda: self.base_panel.back())
+            self.keybinding_system.register_handler(
+                "go_back_home", lambda: self._menu_go_back(home=True)
+            )
+            logging.info("Keybinding system initialized")
+        except Exception as e:
+            logging.error(f"Failed to initialize keybinding system: {e}")
+            # Create a minimal no-op keybinding system
+            self.keybinding_system = None
+
         self.gtk = KlippyGtk(self)
         self.base_css = ""
         self.load_base_styles()
@@ -1358,11 +1386,24 @@ class KlipperScreen(Gtk.Window):
             entry.set_sensitive(True)
 
     def _key_press_event(self, widget, event):
-        keyval_name = Gdk.keyval_name(event.keyval)
-        if keyval_name == "Escape":
-            self._menu_go_back(home=True)
-        elif keyval_name == "BackSpace" and len(self._cur_panels) > 1 and self.keyboard is None:
-            self.base_panel.back()
+        # Check if text entry has focus - pass through to GTK
+        focused = widget.get_focus()
+        if isinstance(focused, Gtk.Entry):
+            return False  # Let GTK handle text entry
+
+        # Check screensaver - only allow wake
+        if self.screensaver.is_showing:
+            self.screensaver.close()
+            return True
+
+        # Delegate to keybinding system if available
+        if self.keybinding_system:
+            handled = self.keybinding_system.handle_key_event(event)
+            if handled:
+                return True
+
+        # If keybinding system didn't handle it, ignore the key
+        return False
 
     def update_size(self, *args):
         width, height = self.get_size()


### PR DESCRIPTION
## Summary
  Adds a config-driven keybinding system for keyboard navigation and alternative input devices where key mapping might not be an option.

  ## Changes
  - Config-driven keybinding system with keygroups, accumulators, and context resolution
  - Panel-specific and global keybinding support
  - Removed hardcoded Escape/Backspace (now opt-in via config)
  - Security: accumulators cleared on screen lock
  - Various standard US ASCII keygroup avaliable as library
  - Example configurations for basic and advanced usage
  - Complete documentation

  ## Use Cases
  - Custom accessibility devices with uncommon keys
  - HID device integration (barcode/QR scanners)
  - General keyboard navigation

  ## Testing
  Tested on local machine (Ubuntu 22.04 LTS paired with mainsail-crew/virtual-klipper-printer)

  ## Breaking Changes
  None. Keybindings are opt-in; existing behavior re-implemented as config (default_navigation.cfg).