### PR TITLE
ci: bump python to v3.11

### DIFF
--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install ruff
         run: pip install ruff
       - name: Run ruff check

--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Install ruff


### PR DESCRIPTION
3.11 is used in bookworm. debian trixie uses py3.13