### PR TITLE
fix(network): avoid panel crash when interface has no IPv4 config yet (null path "/")

### DIFF
--- a/ks_includes/sdbus_nm.py
+++ b/ks_includes/sdbus_nm.py
@@ -150,6 +150,13 @@ class SdbusNm:
             for device_path in active_conn.devices:
                 dev_obj = NetworkDeviceGeneric(device_path)
                 if dev_obj.interface == iface:
+                    # A connection still activating (no lease yet) reports the null
+                    # D-Bus object path "/" for ip4_config; building an IPv4Config
+                    # proxy on "/" and reading a property raises "Object does not
+                    # exist at path /", which crashes the whole network panel. Guard
+                    # it the same way get_primary_interface() already does.
+                    if active_conn.ip4_config == "/":
+                        return "?"
                     ip_info = IPv4Config(active_conn.ip4_config)
                     if ip_info.address_data:
                         return ip_info.address_data[0]["address"][1]

--- a/ks_includes/sdbus_nm.py
+++ b/ks_includes/sdbus_nm.py
@@ -150,11 +150,7 @@ class SdbusNm:
             for device_path in active_conn.devices:
                 dev_obj = NetworkDeviceGeneric(device_path)
                 if dev_obj.interface == iface:
-                    # A connection still activating (no lease yet) reports the null
-                    # D-Bus object path "/" for ip4_config; building an IPv4Config
-                    # proxy on "/" and reading a property raises "Object does not
-                    # exist at path /", which crashes the whole network panel. Guard
-                    # it the same way get_primary_interface() already does.
+                    # A connection with no lease yet reports "/"
                     if active_conn.ip4_config == "/":
                         return "?"
                     ip_info = IPv4Config(active_conn.ip4_config)


### PR DESCRIPTION
## Problem

Opening the **Network** panel crashes with **"Unable to load panel network"** and the traceback:

```
sdbus.dbus_exceptions.DbusUnknownMethodError: Object does not exist at path "/"
  File "panels/network.py", line 85, in __init__
    self.labels["ip"].set_text(f"IP: {self.sdbus_nm.get_ip_for_interface(self.interface)}")
  File "ks_includes/sdbus_nm.py", line 154, in get_ip_for_interface
```

(The same crash also fires via `update_all_networks()` right after a connect attempt.)

## Root cause

`get_ip_for_interface()` builds `IPv4Config(active_conn.ip4_config)` without checking
whether `ip4_config` is the **null D-Bus object path `"/"`**. A connection that is still
*activating* (no DHCP lease yet) reports `"/"` for `ip4_config`; constructing an
`IPv4Config` proxy on `"/"` and then reading `.address_data` raises
`DbusUnknownMethodError: Object does not exist at path "/"`. The exception is uncaught and
takes down the whole panel.

This is easy to hit on a **freshly imaged device with no saved Wi-Fi**: the panel queries
the interface IP while the connection is mid-activation (or while a just-tapped network is
still associating).

## Reproduction

```python
import sdbus
from sdbus_block.networkmanager import IPv4Config
sdbus.set_default_bus(sdbus.sd_bus_open_system())
IPv4Config("/").address_data   # -> DbusUnknownMethodError: Object does not exist at path "/"
```

## Fix

Guard against the null path before constructing the proxy — mirroring the existing
`self.nm.primary_connection == "/"` check in `get_primary_interface()` — and return `"?"`
until an IPv4 config exists. Happy path (a connection with a real IPv4 config) is unchanged.

Verified on a BTT Pad (NetworkManager 1.52.1, Python 3.13): the panel now loads with no
connection, `get_ip_for_interface()` returns the real IP for connected interfaces and `"?"`
for interfaces without an active IPv4 config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
