### PR TITLE
Fix hardcoded heater graph grid color to use theme color

### DIFF
--- a/ks_includes/widgets/heatergraph.py
+++ b/ks_includes/widgets/heatergraph.py
@@ -82,16 +82,20 @@ class HeaterGraph(Gtk.DrawingArea):
     def draw_graph(self, da: Gtk.DrawingArea, ctx: cairoContext):
         if not self.printer.tempstore:
             return
+        style_context = da.get_style_context()
         Gtk.render_background(
-            da.get_style_context(), ctx, 0, 0, da.get_allocated_width(), da.get_allocated_height()
+            style_context, ctx, 0, 0, da.get_allocated_width(), da.get_allocated_height()
         )
+        success, color = style_context.lookup_color("lines")
+        if not success:
+            color = Gdk.RGBA(0.5, 0.5, 0.5, 1.0)
         x = round(self.font_size * 2.75)
         y = 10
         width = da.get_allocated_width() - 15
         height = da.get_allocated_height() - self.font_size * 2
         gsize = [[x, y], [width, height]]
 
-        ctx.set_source_rgb(0.5, 0.5, 0.5)
+        ctx.set_source_rgb(color.red, color.green, color.blue)
         ctx.set_line_width(1)
         ctx.set_tolerance(1)
 
@@ -106,8 +110,8 @@ class HeaterGraph(Gtk.DrawingArea):
             return
         d_width = 1 / points_per_pixel
 
-        d_height_scale = self.graph_lines(ctx, gsize, max_num)
-        self.graph_time(ctx, gsize, points_per_pixel)
+        d_height_scale = self.graph_lines(ctx, gsize, max_num, color)
+        self.graph_time(ctx, gsize, points_per_pixel, color)
 
         for name in self.store:
             if not self.store[name]["show"]:
@@ -163,7 +167,7 @@ class HeaterGraph(Gtk.DrawingArea):
         else:
             ctx.stroke()
 
-    def graph_lines(self, ctx: cairoContext, gsize, max_num):
+    def graph_lines(self, ctx: cairoContext, gsize, max_num, color):
         nscale = 10
         max_num = min(max_num, self.max_temp)
         while (max_num / nscale) > 5:
@@ -173,18 +177,18 @@ class HeaterGraph(Gtk.DrawingArea):
         ctx.set_font_size(self.font_size)
 
         for i in range(r):
-            ctx.set_source_rgb(0.5, 0.5, 0.5)
+            ctx.set_source_rgb(color.red, color.green, color.blue)
             lheight = gsize[1][1] - nscale * i * hscale
             ctx.move_to(6, lheight + 3)
             ctx.show_text(str(nscale * i).rjust(3, " "))
             ctx.stroke()
-            ctx.set_source_rgba(0.5, 0.5, 0.5, 0.2)
+            ctx.set_source_rgba(color.red, color.green, color.blue, 0.2)
             ctx.move_to(gsize[0][0], lheight)
             ctx.line_to(gsize[1][0], lheight)
             ctx.stroke()
         return hscale
 
-    def graph_time(self, ctx: cairoContext, gsize, points_per_pixel):
+    def graph_time(self, ctx: cairoContext, gsize, points_per_pixel, color):
         now = datetime.datetime.now()
         first = gsize[1][0] - (now.second + ((now.minute % 2) * 60)) / points_per_pixel
         steplen = 120 / points_per_pixel  # For 120s
@@ -197,12 +201,12 @@ class HeaterGraph(Gtk.DrawingArea):
             x = first - i * steplen
             if x < gsize[0][0]:
                 break
-            ctx.set_source_rgba(0.5, 0.5, 0.5, 0.2)
+            ctx.set_source_rgba(color.red, color.green, color.blue, 0.2)
             ctx.move_to(x, gsize[0][1])
             ctx.line_to(x, gsize[1][1])
             ctx.stroke()
 
-            ctx.set_source_rgb(0.5, 0.5, 0.5)
+            ctx.set_source_rgb(color.red, color.green, color.blue)
             ctx.move_to(x - font_size_multiplier, gsize[1][1] + font_size_multiplier)
 
             ctx.show_text(f"{now - datetime.timedelta(minutes=2) * i:%H:%M}")


### PR DESCRIPTION
**Current Issue**

The heater graph in the codebase used hardcoded gray rgb(0.5, 0.5, 0.5) for grid lines, border, and text labels. This
caused visibility issues when the application background was set to a low-saturation grayish color,
significantly hindering legibility. Users with custom themes or specific color schemes would find the graph's grid lines
and labels nearly invisible against the background, making temperature readings difficult to interpret.

<img width="980" height="612" alt="Screenshot_before" src="https://github.com/user-attachments/assets/97841b77-668d-429c-a320-3299c59549ff" />

**Root Cause**

In ks_includes/widgets/heatergraph.py, five instances of Cairo drawing commands used hardcoded RGB values instead of
reading from the GTK theme system:
- Line 94: Graph border rectangle
- Line 176: Y-axis temperature labels
- Line 181: Horizontal grid lines (with 0.2 opacity)
- Line 200: Vertical grid lines (with 0.2 opacity)
- Line 205: X-axis time labels

While the temperature data lines correctly used theme-driven colors via get_temp_color(), the graph infrastructure
(grid, border, labels) remained hardcoded, creating an inconsistency in the theming system.

**Solution**

Modified the heater graph to read the @lines color from the CSS theme using GTK's style context API:

1. Retrieve the style context once at the start of draw_graph()
2. Look up the @lines color via style_context.lookup_color("lines")
3. Pass the color to helper methods graph_lines() and graph_time()
4. Replace all hardcoded rgb(0.5, 0.5, 0.5) instances with color.red, color.green, color.blue
5. Maintain 0.2 opacity for grid lines using set_source_rgba(color.red, color.green, color.blue, 0.2)
6. Include fallback to original gray if color lookup fails, ensuring backward compatibility

**Design Considerations**

Seamless Integration:
- Uses existing @lines CSS color variable (defined as #cccccc in base themes)
- Follows the same pattern already used for background rendering (Gtk.render_background())
- No API changes or breaking modifications to HeaterGraph constructor
- Automatically adapts to theme changes without code modifications
- Consistent with how other UI elements retrieve theme colors

No Style Pattern Breakage:
- Respects the existing theme hierarchy and CSS cascade
- Works with all current themes (z-bolt, material-darker, etc.)
- Maintains visual distinction: subtle grid lines (0.2 opacity) vs. prominent labels and border (full opacity)
- Preserves the original opacity behavior for grid lines while making them theme-aware

**Testing**

Tested on Ubuntu 22.04 with mainsail-crew/virtual-klipper-printer simulator. Verified that:
- Grid lines remain visible against various background colors
- Theme changes properly propagate to graph elements
- No regression in graph rendering performance or functionality

<img width="980" height="612" alt="Screenshot_after" src="https://github.com/user-attachments/assets/908a6dd9-e353-40c6-8354-2e5d350a755f" />
