### PR TITLE
ci: add pre-commit to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
see https://github.blog/changelog/2026-03-10-dependabot-now-supports-pre-commit-hooks/