### PR TITLE
Increase precision of pressure advance label

### DIFF
--- a/panels/job_status.py
+++ b/panels/job_status.py
@@ -591,7 +591,7 @@ class Panel(ScreenPanel):
                     f"{data['toolhead']['max_accel']:.0f} {self.mms2}"
                 )
         if "extruder" in data and "pressure_advance" in data["extruder"]:
-            self.labels["advance"].set_label(f"{data['extruder']['pressure_advance']:.2f}")
+            self.labels["advance"].set_label(f"{data['extruder']['pressure_advance']:.3f}")
 
         if "gcode_move" in data:
             if "gcode_position" in data["gcode_move"]:


### PR DESCRIPTION
While printing the [Pressure Advance calibration test](https://www.orcaslicer.com/wiki/calibration/pressure_advance_calib#line-method) in Orcaslicer, I noticed the PA value only changed every 0.1 increment, not showing the actual pressure advance increase of 0.02:

<img width="947" height="587" alt="image" src="https://github.com/user-attachments/assets/f1a1cec5-748b-411c-af2f-7b2256059d39" />

Turns out the decimals was set to 2, so I increased it to 3.