### PR TITLE
Cache compiled Jinja templates used by menu enable evaluation

### DIFF
--- a/panels/menu.py
+++ b/panels/menu.py
@@ -5,7 +5,6 @@ import gi
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
-from jinja2 import Template
 
 from ks_includes.screen_panel import ScreenPanel
 from ks_includes.widgets.autogrid import AutoGrid

--- a/panels/menu.py
+++ b/panels/menu.py
@@ -16,6 +16,7 @@ class Panel(ScreenPanel):
         super().__init__(screen, title)
         self.items = items
         self.j2_data = self._printer.get_printer_status_data()
+        self._compiled_enable = {}
         self.create_menu_items()
         self.scroll = self._gtk.ScrolledWindow()
         self.scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
@@ -105,12 +106,23 @@ class Panel(ScreenPanel):
             self.labels[key] = b
 
     def evaluate_enable(self, enable):
+        if enable == "True":
+            return True
+
+        if enable == "False":
+            return False
+
         if enable == "{{ moonraker_connected }}":
-            logging.info(f"moonraker connected {self._screen.state.connected}")
             return self._screen.state.connected
+
         try:
-            j2_temp = Template(enable, autoescape=True)
-            return j2_temp.render(self.j2_data) == "True"
+            tmpl = self._compiled_enable.get(enable)
+            if tmpl is None:
+                tmpl = self._screen.env.from_string(enable)
+                self._compiled_enable[enable] = tmpl
+
+            return tmpl.render(self.j2_data) == "True"
+
         except Exception as e:
             logging.debug(f"Error evaluating enable statement: {enable}\n{e}")
             return False


### PR DESCRIPTION
## Summary

Cache compiled Jinja templates used by `evaluate_enable()`.

Previously every call parsed and compiled the template before rendering it, even when the same enable expression was evaluated repeatedly.

This change caches compiled templates keyed by their template string and reuses them on subsequent evaluations.

## Benefits

- Avoids repeated Jinja compilation
- Preserves existing behaviour
- Dynamic expressions are still rendered on every evaluation
- Improves menu responsiveness on lower-powered hardware

## Notes

Special cases (`True`, `False`, and `{{ moonraker_connected }}`) continue to use the existing fast path.