### PR TITLE
Avoid unnecessary reloads of the G-code macro panel

### DIFF
--- a/panels/gcode_macros.py
+++ b/panels/gcode_macros.py
@@ -49,7 +49,8 @@ class Panel(ScreenPanel):
         self.labels["options_menu"].add(self.labels["options"])
 
     def activate(self):
-        self.reload_macros()
+        if not self.macros:
+            self.reload_macros()
 
     def add_gcode_macro(self, macro):
         section = self._printer.get_macro(macro)
@@ -199,8 +200,7 @@ class Panel(ScreenPanel):
         for macro in list(self.options):
             self.add_option("options", self.options, macro, self.options[macro])
         macros = sorted(self.macros, reverse=self.sort_reverse, key=str.casefold)
-        for macro in macros:
-            pos = macros.index(macro)
+        for pos, macro in enumerate(macros):
             self.labels["macros"].insert_row(pos)
             self.labels["macros"].attach(self.macros[macro]["row"], 0, pos, 1, 1)
             self.labels["macros"].show_all()
@@ -208,6 +208,5 @@ class Panel(ScreenPanel):
     def back(self):
         if len(self.menu) > 1:
             self.unload_menu()
-            self.reload_macros()
             return True
         return False

--- a/panels/gcode_macros.py
+++ b/panels/gcode_macros.py
@@ -23,6 +23,7 @@ class Panel(ScreenPanel):
         self.options = {}
         self.macros = {}
         self.menu = ["macros_menu"]
+        self.macros_dirty = True
 
         adjust = self._gtk.Button(
             "settings", " " + _("Settings"), "color2", self.bts, Gtk.PositionType.LEFT, 1
@@ -49,8 +50,10 @@ class Panel(ScreenPanel):
         self.labels["options_menu"].add(self.labels["options"])
 
     def activate(self):
-        if not self.macros:
-            self.reload_macros()
+        self.reload_macros()
+
+    def macro_visibility_changed(self, active):
+        self.macros_dirty = True
 
     def add_gcode_macro(self, macro):
         section = self._printer.get_macro(macro)
@@ -177,6 +180,11 @@ class Panel(ScreenPanel):
         GLib.idle_add(self.reload_macros)
 
     def reload_macros(self):
+        if not self.macros_dirty:
+            return
+
+        self.macros_dirty = False
+
         self.labels["macros"].remove_column(0)
         self.macros = {}
         self.options = {}
@@ -190,6 +198,7 @@ class Panel(ScreenPanel):
                 "name": macro,
                 "section": f"displayed_macros {self._screen.state.printer_name}",
                 "type": "binary",
+                "callback": self.macro_visibility_changed,
             }
             show = self._config.get_config().getboolean(
                 self.options[macro]["section"], macro.lower(), fallback=True
@@ -208,5 +217,6 @@ class Panel(ScreenPanel):
     def back(self):
         if len(self.menu) > 1:
             self.unload_menu()
+            self.reload_macros()
             return True
         return False


### PR DESCRIPTION
This change avoids rebuilding the G-code macro panel when it is revisited.

The macro list is now populated only when needed, instead of every time the panel is activated or when leaving the options submenu.

Additionally, replace macros.index() with enumerate() while constructing the macro list.