### PR TITLE
Render multi-color Spoolman spools as a gradient icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Probably all versions contain changes regarding documentation, translation, fixe
 * network interface selector includes wired connections
 * add a shortcut from titlebar item to respective panels (temp/spoolman)
 * add a configurable screensaver delay for slow to wake displays
+* render multi-color spools (Spoolman multi_color_hexes) as a gradient in the spoolman icon, instead of black
 
 ## v0.4.7  (May 13, 2026)
 

--- a/ks_includes/svg_gradient.py
+++ b/ks_includes/svg_gradient.py
@@ -1,0 +1,107 @@
+import re
+
+# Matches any element using the `fill:var(--filament-color)` placeholder, regardless
+# of which theme's spool.svg it comes from or how that theme shapes the filament
+# coil (a plain rect, a curved wedge, one shape, two shapes, etc).
+FILAMENT_COLOR_RE = re.compile(r"<path[^>]*?fill:var\(--filament-color\)[^>]*?/>")
+SVG_TAG_RE = re.compile(r"(<svg\b[^>]*>)")
+VIEWBOX_RE = re.compile(r'viewBox="\s*[\d.\-]+\s+[\d.\-]+\s+([\d.]+)\s+([\d.]+)\s*"')
+
+DEFAULT_COLOR = "000000"
+
+
+def normalize_hex(value):
+    """Strip whitespace/leading '#' from a single color value."""
+    return value.strip().lstrip("#")
+
+
+def filament_colors_from_dict(filament):
+    """
+    Resolve the ordered list of filament colors from a Spoolman filament
+    dict (as returned over the Moonraker API): prefer multi_color_hexes
+    (comma separated) when present, falling back to the single color_hex,
+    and finally to a default so callers always get at least one color.
+    """
+    if not filament:
+        return [DEFAULT_COLOR]
+
+    multi = filament.get("multi_color_hexes")
+    if isinstance(multi, str) and multi.strip():
+        colors = [normalize_hex(c) for c in multi.split(",") if c.strip()]
+        if colors:
+            return colors
+
+    color = filament.get("color_hex")
+    if isinstance(color, str) and color.strip():
+        return [normalize_hex(color)]
+
+    return [DEFAULT_COLOR]
+
+
+def _gradient_stops(colors):
+    n = len(colors)
+    if n <= 1:
+        color = colors[0] if colors else DEFAULT_COLOR
+        return f'<stop offset="0" stop-color="#{color}"/><stop offset="1" stop-color="#{color}"/>'
+    return "".join(
+        f'<stop offset="{i / (n - 1):.4f}" stop-color="#{c}"/>' for i, c in enumerate(colors)
+    )
+
+
+def apply_filament_gradient(svg_text, colors):
+    """
+    Recolor a spool icon's filament-colored elements with a single smooth
+    top-to-bottom gradient through `colors`, in order (first color nearest
+    the spool's near/inner face, shifting through to the last color at the
+    outer edge).
+
+    This works generically across every theme's spool.svg without knowing
+    its geometry: whichever elements use `fill:var(--filament-color)` are
+    cloned into an SVG <mask> (preserving their exact original shape), and
+    a single gradient-filled rect is painted through that mask in place of
+    the first such element. Any additional filament-color elements are
+    dropped, since the mask already covers their combined silhouette.
+
+    A single color behaves exactly like the previous plain fill (no mask
+    or gradient overhead), so this is a drop-in replacement.
+    """
+    if not colors:
+        return svg_text.replace("var(--filament-color)", f"#{DEFAULT_COLOR}")
+    if len(colors) == 1:
+        return svg_text.replace("var(--filament-color)", f"#{colors[0]}")
+
+    matches = list(FILAMENT_COLOR_RE.finditer(svg_text))
+    if not matches:
+        return svg_text
+
+    width, height = 235, 500
+    viewbox_match = VIEWBOX_RE.search(svg_text)
+    if viewbox_match:
+        width, height = float(viewbox_match.group(1)), float(viewbox_match.group(2))
+
+    mask_shapes = "".join(
+        re.sub(r"fill:var\(--filament-color\)", "fill:#ffffff", match.group(0)) for match in matches
+    )
+
+    grad_id, mask_id = "filamentGradient", "filamentMask"
+    defs = (
+        "<defs>"
+        f'<linearGradient id="{grad_id}" gradientUnits="userSpaceOnUse" '
+        f'x1="0" y1="0" x2="0" y2="{height}">{_gradient_stops(colors)}</linearGradient>'
+        f'<mask id="{mask_id}" maskUnits="userSpaceOnUse" x="0" y="0" '
+        f'width="{width}" height="{height}">'
+        f'<rect x="0" y="0" width="{width}" height="{height}" fill="black"/>'
+        f"{mask_shapes}"
+        "</mask>"
+        "</defs>"
+    )
+    gradient_rect = (
+        f'<rect x="0" y="0" width="{width}" height="{height}" '
+        f'fill="url(#{grad_id})" mask="url(#{mask_id})"/>'
+    )
+
+    first = matches[0]
+    out = svg_text[: first.start()] + gradient_rect + svg_text[first.end() :]
+    out = FILAMENT_COLOR_RE.sub("", out)
+    out = SVG_TAG_RE.sub(lambda m: m.group(1) + defs, out, count=1)
+    return out

--- a/panels/base_panel.py
+++ b/panels/base_panel.py
@@ -13,6 +13,7 @@ from gi.repository import GdkPixbuf, Gio, GLib, Gtk, Pango
 from jinja2 import Environment
 
 from ks_includes.screen_panel import ScreenPanel
+from ks_includes.svg_gradient import apply_filament_gradient, filament_colors_from_dict
 
 try:
     import psutil
@@ -37,7 +38,7 @@ class BasePanel(ScreenPanel):
         self.titlebar_labels = {}
         self.titlebar_populated = False
         self.spoolman_low_limit = 20
-        self.spoolman_current_color = None
+        self.spoolman_current_colors = None
         self.current_extruder = None
         self.last_usage_report = datetime.now()
         self.usage_report = 0
@@ -184,9 +185,9 @@ class BasePanel(ScreenPanel):
         self.battery_icons = self.load_battery_icons()
         self.battery_percentage()
 
-    def get_spoolman_icon_pixbuf(self, color=None):
-        if not color:
-            self.get_active_spoolman_color()
+    def get_spoolman_icon_pixbuf(self, colors=None):
+        if not colors:
+            colors = self.get_active_spoolman_colors()
         klipperscreendir = pathlib.Path(__file__).parent.resolve().parent
         icon_path = os.path.join(
             klipperscreendir, "styles", self._screen.theme, "images", "spool.svg"
@@ -196,7 +197,7 @@ class BasePanel(ScreenPanel):
             icon_path = os.path.join(klipperscreendir, "styles", "spool.svg")
         try:
             svg = pathlib.Path(icon_path).read_text(encoding="utf-8")
-            svg = svg.replace("var(--filament-color)", f"#{color}")
+            svg = apply_filament_gradient(svg, colors)
             stream = Gio.MemoryInputStream.new_from_data(svg.encode(), None)
             pixbuf = GdkPixbuf.Pixbuf.new_from_stream_at_scale(
                 stream,
@@ -211,20 +212,15 @@ class BasePanel(ScreenPanel):
             logging.error(f"Couldn't load spoolman icon: {e}")
             return self._gtk.PixbufFromIcon("spool", icon_size, icon_size)
 
-    def get_active_spoolman_color(self):
-        default_color = "000000"
+    def get_active_spoolman_colors(self):
         if (
             self._printer is None
             or not self._printer.active_spool
             or "filament" not in self._printer.active_spool
             or not self._printer.active_spool["filament"]
         ):
-            return default_color
-        filament = self._printer.active_spool["filament"]
-        color = filament.get("color_hex")
-        if isinstance(color, str):
-            return color.strip().lstrip("#") or default_color
-        return default_color
+            return filament_colors_from_dict(None)
+        return filament_colors_from_dict(self._printer.active_spool["filament"])
 
     def show_titlebar_items(self):
         if self.titlebar_populated:
@@ -403,10 +399,10 @@ class BasePanel(ScreenPanel):
         remaining_weight = self._printer.active_spool["remaining_weight"]
         self.labels["spoolman_weight"].set_label(f"{round(remaining_weight):.0f} g")
         self.update_spoolman_alert_visuals(remaining_weight <= self.spoolman_low_limit)
-        color = self.get_active_spoolman_color()
-        if color != self.spoolman_current_color:
-            self.labels["spoolman_icon"].set_from_pixbuf(self.get_spoolman_icon_pixbuf(color))
-            self.spoolman_current_color = color
+        colors = self.get_active_spoolman_colors()
+        if colors != self.spoolman_current_colors:
+            self.labels["spoolman_icon"].set_from_pixbuf(self.get_spoolman_icon_pixbuf(colors))
+            self.spoolman_current_colors = colors
 
     def fetch_spoolman(self):
         if (

--- a/panels/spoolman.py
+++ b/panels/spoolman.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from gi.repository import Gdk, GdkPixbuf, GLib, GObject, Gtk, Pango
 
 from ks_includes.screen_panel import ScreenPanel
+from ks_includes.svg_gradient import apply_filament_gradient, filament_colors_from_dict
 from ks_includes.widgets.combo import ComboBoxPlus
 
 try:
@@ -52,6 +53,8 @@ class SpoolmanVendor:
 class SpoolmanFilament:
     article_number: str
     color_hex: str
+    multi_color_hexes: str
+    multi_color_direction: str
     comment: str
     density: float
     diameter: float
@@ -113,6 +116,10 @@ class SpoolmanSpool(GObject.GObject):
         return " - ".join(parts) if parts else self.filament.name
 
     @property
+    def _filament_colors(self):
+        return filament_colors_from_dict(vars(self.filament) if self.filament else None)
+
+    @property
     def icon(self):
         if self._icon is None:
             if SpoolmanSpool._spool_icon is None:
@@ -124,11 +131,9 @@ class SpoolmanSpool(GObject.GObject):
                     _spool_icon_path = os.path.join(klipperscreendir, "styles", "spool.svg")
                 SpoolmanSpool._spool_icon = pathlib.Path(_spool_icon_path).read_text()
 
+            svg = apply_filament_gradient(SpoolmanSpool._spool_icon, self._filament_colors)
             loader = GdkPixbuf.PixbufLoader()
-            color = self.filament.color_hex if hasattr(self.filament, "color_hex") else "000000"
-            loader.write(
-                SpoolmanSpool._spool_icon.replace("var(--filament-color)", f"#{color}").encode()
-            )
+            loader.write(svg.encode())
             loader.close()
             self._icon = loader.get_pixbuf()
         return self._icon


### PR DESCRIPTION
## Problem

Spoolman filaments store multi-color data in `multi_color_hexes` (and `multi_color_direction`) instead of `color_hex`. KlipperScreen only ever reads `color_hex`, so any multi-color spool renders as solid black in both the titlebar spoolman widget and the spool list/detail panel — `color_hex` is `null` for these filaments, and the code has no fallback.

I couldn't find an existing open issue for this (searched title/body for "spoolman", "spool", "color", "multicolor", "multi-color", "multi_color_hexes" — nothing matches), so this PR doesn't close anything specific.

## Fix

- `ks_includes/svg_gradient.py` (new): `filament_colors_from_dict()` resolves a spool's ordered color list, preferring `multi_color_hexes` and falling back to `color_hex`, then black. `apply_filament_gradient()` recolors a spool icon with a single smooth top-to-bottom gradient through those colors.
- Works generically across all five bundled themes' `spool.svg` files without any per-theme geometry: it clones whichever elements use `fill:var(--filament-color)` into an SVG `<mask>` (preserving each theme's exact filament-coil shape, whatever it looks like), then paints one gradient rect through that mask.
- Single-color spools are unaffected — same plain fill as before, byte-for-byte, no mask/gradient overhead.
- `panels/spoolman.py` and `panels/base_panel.py` updated to use the shared helper (spool list icon and titlebar icon respectively).

## Design note

This renders coaxial and longitudinal multi-color filaments identically (one gradient, first color nearest the spool's near face, shifting outward). I considered rendering these two cases differently but decided the added complexity wasn't worth it for a small titlebar/list icon — happy to revisit if maintainers feel otherwise.

## Testing

- `ruff check` / `ruff format` clean against the paths CI lints.
- Unit-level assertions on color resolution (multi vs. single vs. empty/whitespace vs. missing).
- Confirmed the single-color path is identical to the previous behavior.
- Rendered the actual shipped code against all 6 `spool.svg` files (default + 5 themes) to confirm no leftover `var(--filament-color)` placeholders and valid output.
- Tested live on two separate physical setups, both on the `z-bolt` theme: a Qidi X-Plus3 with KlipperScreen on a dedicated Pi, and a Trident 350 with KlipperScreen running on its Manta M8P mainboard and 5-inch HDMI screen (Siboor June AWD kit). Confirmed working on both.