### PR TITLE
fix: ensure spoolman ID column does not truncate for values > 99

### DIFF
--- a/panels/spoolman.py
+++ b/panels/spoolman.py
@@ -280,9 +280,13 @@ class Panel(ScreenPanel):
         text_renderer.set_property("ellipsize", Pango.EllipsizeMode.END)
         pixbuf_renderer = Gtk.CellRendererPixbuf(xpad=5, ypad=5)
         checkbox_renderer = Gtk.CellRendererToggle()
-        column_id = Gtk.TreeViewColumn(cell_renderer=text_renderer)
-        column_id.set_cell_data_func(text_renderer, self._set_cell_id)
+        # Ensure id column does not ellipsize text
+        id_renderer = Gtk.CellRendererText()
+
+        column_id = Gtk.TreeViewColumn(cell_renderer=id_renderer)
+        column_id.set_cell_data_func(id_renderer, self._set_cell_id)
         column_id.set_sort_column_id(0)
+        column_id.set_min_width(60)
 
         column_icon = Gtk.TreeViewColumn(cell_renderer=pixbuf_renderer)
         column_icon.set_cell_data_func(pixbuf_renderer, self._set_cell_icon)

--- a/panels/spoolman.py
+++ b/panels/spoolman.py
@@ -286,7 +286,6 @@ class Panel(ScreenPanel):
         column_id = Gtk.TreeViewColumn(cell_renderer=id_renderer)
         column_id.set_cell_data_func(id_renderer, self._set_cell_id)
         column_id.set_sort_column_id(0)
-        column_id.set_min_width(60)
 
         column_icon = Gtk.TreeViewColumn(cell_renderer=pixbuf_renderer)
         column_icon.set_cell_data_func(pixbuf_renderer, self._set_cell_icon)


### PR DESCRIPTION
Issue: Spoolman cuts off IDs > 99

This PR fixes the rendering issue by creating and supplying a new renderer without ellipsize enabled and sets a minimum width to ensure the ID column is always rendered appropriately.

### Old:

ID column ellipsized not displaying IDs > 99

<img width="801" height="481" alt="image" src="https://github.com/user-attachments/assets/81306888-4b30-4da3-b371-221fc336487b" />


### New:

ID column with fixed width and no ellipsize mode configured

<img width="862" height="517" alt="image" src="https://github.com/user-attachments/assets/f93e8f0f-503e-4a89-81e4-85eca188b1aa" />
