### PR TITLE
Lazy-load KlippyRest

### DIFF
--- a/ks_includes/KlippyGtk.py
+++ b/ks_includes/KlippyGtk.py
@@ -198,7 +198,7 @@ class KlippyGtk:
             return
 
         def _load():
-            response = self.screen.restApi.get_thumbnail_stream(resource)
+            response = self.screen.get_rest_api().get_thumbnail_stream(resource)
             if response is False:
                 GLib.idle_add(callback, None)
                 return

--- a/panels/camera.py
+++ b/panels/camera.py
@@ -61,7 +61,7 @@ class Panel(ScreenPanel):
         url = cam["stream_url"]
         if url.startswith("/"):
             logging.info("camera URL is relative")
-            endpoint = self._screen.restApi.endpoint.split(":")
+            endpoint = self._screen.get_rest_api().endpoint.split(":")
             url = f"{endpoint[0]}:{endpoint[1]}{url}"
         if "/webrtc" in url:
             self._screen.show_popup_message(

--- a/panels/gcodes.py
+++ b/panels/gcodes.py
@@ -482,7 +482,7 @@ class Panel(ScreenPanel):
                 _("Estimated Time") + f": <b>{self.format_time(fileinfo['estimated_time'])}</b>\n"
             )
         if "job_id" in fileinfo:
-            history = self._screen.restApi.send_request(
+            history = self._screen.get_rest_api().send_request(
                 f"server/history/job?uid={fileinfo['job_id']}"
             )
             if history and history["job"]["status"] == "completed":

--- a/panels/led.py
+++ b/panels/led.py
@@ -129,7 +129,7 @@ class Panel(ScreenPanel):
         grid.attach(scale_grid, 0, 0, 3, 1)
 
         columns = 3 if self._screen.vertical_mode else 2
-        data_misc = self._screen.restApi.send_request(
+        data_misc = self._screen.get_rest_api().send_request(
             "server/database/item?namespace=mainsail&key=miscellaneous.entries"
         )
         if data_misc:

--- a/panels/shutdown.py
+++ b/panels/shutdown.py
@@ -80,7 +80,7 @@ class Panel(ScreenPanel):
                 }
             )
         else:
-            logging.info(self._screen.restApi.endpoint)
+            logging.info(self._screen.get_rest_api().endpoint)
             buttons.extend(
                 [
                     {"name": _("Host"), "response": Gtk.ResponseType.OK, "style": "dialog-info"},

--- a/panels/system.py
+++ b/panels/system.py
@@ -28,7 +28,7 @@ class Panel(ScreenPanel):
         self.sysinfo = screen.printer.system_info
         if not self.sysinfo:
             logging.debug("Asking for info")
-            self.sysinfo = screen.restApi.send_request("machine/system_info")
+            self.sysinfo = screen.get_rest_api().send_request("machine/system_info")
             if "system_info" in self.sysinfo:
                 screen.printer.system_info = self.sysinfo["system_info"]
                 self.sysinfo = self.sysinfo["system_info"]

--- a/screen.py
+++ b/screen.py
@@ -27,7 +27,6 @@ from ks_includes import functions
 from ks_includes.config import KlipperScreenConfig
 from ks_includes.files import KlippyFiles
 from ks_includes.KlippyGtk import KlippyGtk
-from ks_includes.KlippyRest import KlippyRest
 from ks_includes.KlippyUDS import KlippyUDS
 from ks_includes.KlippyWebsocket import KlippyWebsocket
 from ks_includes.notification_handler import NotificationHandler
@@ -76,6 +75,7 @@ class KlipperScreen(Gtk.ApplicationWindow):
         self.printer = None
         self.printers = None
         self.restApi = None
+        self._rest_api_config = None
         self._ws = None
 
         self.keyboard = None
@@ -241,6 +241,12 @@ class KlipperScreen(Gtk.ApplicationWindow):
         self._ws.close()
         self.printer.state = "disconnected"
 
+    def get_rest_api(self):
+        if self.restApi is None:
+            from ks_includes.KlippyRest import KlippyRest
+            self.restApi = KlippyRest(**self._rest_api_config)
+        return self.restApi
+
     def connect_printer(self, name):
         self.state.printer_name = name
         if self._ws is not None and self._ws.connected:
@@ -259,14 +265,15 @@ class KlipperScreen(Gtk.ApplicationWindow):
         moonraker_host = self.printers[ind][name]["moonraker_host"]
         is_uds = moonraker_host.startswith(("/", "~"))
         rest_host = "localhost" if is_uds else moonraker_host
+        self._rest_api_config = {
+            "ip": rest_host,
+            "port": self.printers[ind][name]["moonraker_port"],
+            "api_key": self.printers[ind][name]["moonraker_api_key"],
+            "path": self.printers[ind][name]["moonraker_path"],
+            "ssl": self.printers[ind][name]["moonraker_ssl"],
+        }
 
-        self.restApi = KlippyRest(
-            rest_host,
-            self.printers[ind][name]["moonraker_port"],
-            self.printers[ind][name]["moonraker_api_key"],
-            self.printers[ind][name]["moonraker_path"],
-            self.printers[ind][name]["moonraker_ssl"],
-        )
+        self.restApi = None
         self._notification_handler = NotificationHandler(self)
         self.state.printer_is_local = is_uds or moonraker_host in ("localhost", "127.0.0.1")
 


### PR DESCRIPTION
KlippyRest is now instantiated only when the REST API is actually needed.

This avoids creating the REST client during normal startup while preserving the existing REST API behavior.

Tested:

- KlipperScreen starts normally without initializing KlippyRest.
- REST API functionality triggers initialization when needed.
- git diff --check passes.